### PR TITLE
chore: Specify ash dependency to be ~> 1.0 until official 2.0 release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule AshGraphql.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ash, ash_version("~> 1.11.0")},
+      {:ash, ash_version("~> 1.0")},
       {:absinthe, "~> 1.5.3"},
       {:dataloader, "~> 1.0"},
       {:jason, "~> 1.2"},


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Updates Ash dependency to `~> 1.0` to reduce version bumping.