### PR TITLE
fix: Handle error if multitenant resource was fetched without tenant being set

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 if Mix.env() == :dev do
   config :git_ops,

--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -264,7 +264,8 @@ defmodule AshGraphql do
   end
 
   def add_context(ctx, apis, options \\ []) do
-    empty_dataloader = Dataloader.new(options ++ [get_policy: :tuples])
+    options = Keyword.put(options, :get_policy, :tuples)
+    empty_dataloader = Dataloader.new(options)
 
     dataloader =
       apis

--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -263,11 +263,13 @@ defmodule AshGraphql do
     end)
   end
 
-  def add_context(ctx, apis) do
+  def add_context(ctx, apis, options \\ []) do
+    empty_dataloader = Dataloader.new(options ++ [get_policy: :tuples])
+
     dataloader =
       apis
       |> List.wrap()
-      |> Enum.reduce(Dataloader.new(), fn {api, _registry}, dataloader ->
+      |> Enum.reduce(empty_dataloader, fn {api, _registry}, dataloader ->
         Dataloader.add_source(
           dataloader,
           api,

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -932,6 +932,10 @@ defmodule AshGraphql.Graphql.Resolver do
     child_complexity + 1
   end
 
+  def fetch_dataloader(loader, api, batch_key, parent) do
+    to_resolution(Dataloader.get(loader, api, batch_key, parent))
+  end
+
   defp do_dataloader(
          resolution,
          loader,
@@ -943,7 +947,7 @@ defmodule AshGraphql.Graphql.Resolver do
     loader = Dataloader.load(loader, api, batch_key, parent)
 
     fun = fn loader ->
-      {:ok, Dataloader.get(loader, api, batch_key, parent)}
+      fetch_dataloader(loader, api, batch_key, parent)
     end
 
     Absinthe.Resolution.put_result(

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -154,4 +154,122 @@ defmodule AshGraphql.ErrorsTest do
 
     assert message =~ "is required"
   end
+
+  test "a multitenant object cannot be read if tenant is not set" do
+    assert capture_log(fn ->
+             tenant = "Some Tenant"
+
+             tag =
+               AshGraphql.Test.MultitenantTag
+               |> Ash.Changeset.for_create(
+                 :create,
+                 [name: "My Tag"],
+                 tenant: tenant
+               )
+               |> AshGraphql.Test.Api.create!()
+
+             resp =
+               """
+               query MultitenantTag($id: ID!) {
+                 getMultitenantTag(id: $id) {
+                   name
+                 }
+               }
+               """
+               |> Absinthe.run(AshGraphql.Test.Schema, variables: %{"id" => tag.id})
+
+             assert {:ok, result} = resp
+
+             assert %{data: %{"getMultitenantTag" => nil}, errors: [%{message: message}]} = result
+             assert message =~ "Something went wrong."
+           end) =~
+             "Queries against the AshGraphql.Test.MultitenantTag resource require a tenant to be specified"
+  end
+
+  test "a multitenant object cannot be read without tenant" do
+    assert capture_log(fn ->
+             tenant = "Some Tenant"
+
+             tag =
+               AshGraphql.Test.MultitenantTag
+               |> Ash.Changeset.for_create(
+                 :create,
+                 [name: "My Tag"],
+                 tenant: tenant
+               )
+               |> AshGraphql.Test.Api.create!()
+
+             resp =
+               """
+               query MultitenantTag($id: ID!) {
+                 getMultitenantTag(id: $id) {
+                   name
+                 }
+               }
+               """
+               |> Absinthe.run(AshGraphql.Test.Schema, variables: %{"id" => tag.id})
+
+             assert {:ok, result} = resp
+
+             assert %{data: %{"getMultitenantTag" => nil}, errors: [%{message: message}]} = result
+             assert message =~ "Something went wrong."
+           end) =~
+             "Queries against the AshGraphql.Test.MultitenantTag resource require a tenant to be specified"
+  end
+
+  test "a multitenant relation cannot be read without tenant" do
+    assert capture_log(fn ->
+             tenant = "Some Tenant"
+
+             tag =
+               AshGraphql.Test.MultitenantTag
+               |> Ash.Changeset.for_create(
+                 :create,
+                 [name: "My Tag"],
+                 tenant: tenant
+               )
+               |> AshGraphql.Test.Api.create!()
+
+             post =
+               AshGraphql.Test.Post
+               |> Ash.Changeset.for_create(:create, text: "foo", published: true)
+               |> Ash.Changeset.manage_relationship(
+                 :multitenant_tags,
+                 [tag],
+                 on_no_match: {:create, :create_action},
+                 on_lookup: :relate
+               )
+               |> AshGraphql.Test.Api.create!()
+
+             resp =
+               """
+               query MultitenantPostTag($id: ID!) {
+                 getPost(id: $id) {
+                   text
+                   published
+                   multitenantTags {
+                     name
+                   }
+                 }
+               }
+               """
+               |> Absinthe.run(AshGraphql.Test.Schema, variables: %{"id" => post.id})
+
+             assert {:ok, result} = resp
+
+             assert %{
+                      data: %{
+                        "getPost" => %{
+                          "published" => true,
+                          "text" => "foo",
+                          "multitenantTags" => nil
+                        }
+                      },
+                      errors: [%{message: message}]
+                    } = result
+
+             assert message =~ "Something went wrong."
+           end) =~
+             "Queries against the AshGraphql.Test.MultitenantTag resource require a tenant to be specified"
+  end
 end

--- a/test/support/registry.ex
+++ b/test/support/registry.ex
@@ -7,6 +7,8 @@ defmodule AshGraphql.Test.Registry do
     entry(AshGraphql.Test.CompositePrimaryKey)
     entry(AshGraphql.Test.DoubleRelRecursive)
     entry(AshGraphql.Test.DoubleRelToRecursiveParentOfEmbed)
+    entry(AshGraphql.Test.MultitenantTag)
+    entry(AshGraphql.Test.MultitenantPostTag)
     entry(AshGraphql.Test.NonIdPrimaryKey)
     entry(AshGraphql.Test.NoObject)
     entry(AshGraphql.Test.Post)

--- a/test/support/resources/multitenant_post_tag.ex
+++ b/test/support/resources/multitenant_post_tag.ex
@@ -1,0 +1,18 @@
+defmodule AshGraphql.Test.MultitenantPostTag do
+  @moduledoc false
+
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets
+
+  relationships do
+    belongs_to :post, AshGraphql.Test.Post do
+      primary_key?(true)
+      required?(true)
+    end
+
+    belongs_to :tag, AshGraphql.Test.MultitenantTag do
+      primary_key?(true)
+      required?(true)
+    end
+  end
+end

--- a/test/support/resources/multitenant_tag.ex
+++ b/test/support/resources/multitenant_tag.ex
@@ -1,0 +1,49 @@
+defmodule AshGraphql.Test.MultitenantTag do
+  @moduledoc false
+
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:multitenant_tag)
+
+    queries do
+      get :get_multitenant_tag, :read
+      list :get_multitenant_tags, :read
+    end
+
+    mutations do
+      create :create_multitenant_tag, :create
+      destroy :destroy_multitenant_tag, :destroy
+    end
+  end
+
+  multitenancy do
+    strategy(:context)
+  end
+
+  actions do
+    create :create do
+      primary?(true)
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:name, :string)
+  end
+
+  identities do
+    identity(:name, [:name])
+  end
+
+  relationships do
+    many_to_many(:posts, AshGraphql.Test.Post,
+      through: AshGraphql.Test.MultitenantPostTag,
+      source_field_on_join_table: :tag_id,
+      destination_field_on_join_table: :post_id
+    )
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -201,5 +201,11 @@ defmodule AshGraphql.Test.Post do
       source_field_on_join_table: :post_id,
       destination_field_on_join_table: :tag_id
     )
+
+    many_to_many(:multitenant_tags, AshGraphql.Test.MultitenantTag,
+      through: AshGraphql.Test.MultitenantPostTag,
+      source_field_on_join_table: :post_id,
+      destination_field_on_join_table: :tag_id
+    )
   end
 end


### PR DESCRIPTION
I've played a bit with [example project|https://github.com/ash-project/ash_example], and found an issue.

I've created a simple ticket with id `99bb4bec-b8ea-494e-83da-1f706c44a1e1`, and then tried to execute this query:
```graphql
query {
  getTicket(id: "99bb4bec-b8ea-494e-83da-1f706c44a1e1") {
    id
    description
    response
    representative {
      id
    }
    reporter {
      id
    }
    subject
    status
  }
}
```

It fails because tenant is not set in the context:
[old.log](https://github.com/ash-project/ash_graphql/files/8665107/old.log)

But instead of returning `Something went wrong` in `errors` field, the request is failed with 500 error.

I've changed `dataloader` behavior from raising an exception to returning a tuple `{:error, error}`, so this error could be handled by existing `to_resolution` function.

Now fields which cannot be fetched are not causing all the query to fail, `nil` is returned instead:
```json
{
  "data": {
    "getTicket": {
      "description": null,
      "id": "99bb4bec-b8ea-494e-83da-1f706c44a1e1",
      "reporter": null,
      "representative": null,
      "response": null,
      "status": "NEW",
      "subject": "aasbc"
    }
  },
  "errors": [
    {
      "locations": [
        {
          "column": 5,
          "line": 9
        }
      ],
      "message": "Something went wrong. Unique error id: `e47079eb-223b-432b-8fb4-c01714dc9925`",
      "path": [
        "getTicket",
        "reporter"
      ]
    },
    {
      "locations": [
        {
          "column": 5,
          "line": 6
        }
      ],
      "message": "Something went wrong. Unique error id: `f6a6a465-4164-4f67-9782-17aaca439cce`",
      "path": [
        "getTicket",
        "representative"
      ]
    }
  ]
}
```

But original error message is still printing to the log:
[now.log](https://github.com/ash-project/ash_graphql/files/8665105/now.log)


Also it is now possible to pass custom dataloader options as third argument of `AshGraphql.add_context`.

### Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
