### PR TITLE
docs: Fix constraints example in enum how_to

### DIFF
--- a/documentation/how_to/use-enums-with-graphql.md
+++ b/documentation/how_to/use-enums-with-graphql.md
@@ -6,7 +6,9 @@ Enums are implemented automatically for any `atom` *attribute* (not arguments) w
 
 ```elixir
 # On the resource of type `:ticket`
-attribute :type, :atom, one_of: [:foo, :bar, :baz]
+attribute :type, :atom do
+  constraints one_of: [:foo, :bar, :baz]
+end
 ```
 
 This would produce an enum called `:ticket_type`/`TicketType`.


### PR DESCRIPTION
The Code Snippet gave me a compile error, telling me that `one_of` was not a valid option

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
