### PR TITLE
fix: map uuid action arguments to ID type

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -2977,7 +2977,7 @@ defmodule AshGraphql.Resource do
 
   defp get_specific_field_type(Ash.Type.NaiveDateTime, _, _), do: :naive_datetime
 
-  defp get_specific_field_type(Ash.Type.UUID, _, _), do: :string
+  defp get_specific_field_type(Ash.Type.UUID, _, _), do: :id
   defp get_specific_field_type(Ash.Type.Float, _, _), do: :float
 
   defp get_specific_field_type(type, _, _) do

--- a/test/attribute_test.exs
+++ b/test/attribute_test.exs
@@ -14,6 +14,34 @@ defmodule AshGraphql.AttributeTest do
     end)
   end
 
+  test ":uuid arguments are mapped to ID type" do
+    {:ok, %{data: data}} =
+      """
+      query {
+        __type(name: "SimpleCreatePostInput") {
+          inputFields {
+            name
+            type {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    author_id_field =
+      data["__type"]["inputFields"]
+      |> Enum.find(fn field -> field["name"] == "authorId" end)
+
+    assert author_id_field["type"]["name"] == "ID"
+  end
+
   test "atom attribute with one_of constraints has enums automatically generated" do
     {:ok, %{data: data}} =
       """

--- a/test/read_test.exs
+++ b/test/read_test.exs
@@ -336,7 +336,7 @@ defmodule AshGraphql.ReadTest do
 
     resp =
       """
-      query GetCompositePrimaryKeyNotEncoded($first: String!, $second: String!) {
+      query GetCompositePrimaryKeyNotEncoded($first: ID!, $second: ID!) {
         getCompositePrimaryKeyNotEncoded(first: $first, second: $second) {
           first
           second


### PR DESCRIPTION
Maps uuid action arguments to ID GraphQL type – they were being mapped to the String GraphQL type.