### PR TITLE
fix: always return a list from pkey_fields

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -2872,14 +2872,14 @@ defmodule AshGraphql.Resource do
         attribute = Ash.Resource.Info.attribute(resource, field)
         field_type = maybe_wrap_non_null(:id, require?)
 
-        %Absinthe.Blueprint.Schema.FieldDefinition{
+        [%Absinthe.Blueprint.Schema.FieldDefinition{
           description: attribute.description,
           identifier: field,
           module: schema,
           name: to_string(attribute.name),
           type: field_type,
           __reference__: ref(__ENV__)
-        }
+        }]
 
       fields ->
         for field <- fields do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -87,6 +87,7 @@ defmodule AshGraphql.Test.Post do
       managed_relationship :with_comments, :comments
 
       managed_relationship :with_comments_and_tags, :comments,
+        lookup_with_primary_key?: true,
         type_name: :create_post_comment_with_tag
 
       managed_relationship :with_comments_and_tags, :tags,


### PR DESCRIPTION
### Contributor checklist

The function `manage_pkey_fields` that calls `pkey_fields` could not handle a single value being returned as it tries to map over the result.



- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
