### PR TITLE
Add missing definition for `Ash.Type.Time` type

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3426,6 +3426,7 @@ defmodule AshGraphql.Resource do
     do: Application.get_env(:ash, :utc_datetime_type) || raise_datetime_error()
 
   defp get_specific_field_type(Ash.Type.NaiveDatetime, _, _, _), do: :naive_datetime
+  defp get_specific_field_type(Ash.Type.Time, _, _, _), do: :time
 
   defp get_specific_field_type(Ash.Type.UUID, _, _, _), do: :id
   defp get_specific_field_type(Ash.Type.Float, _, _, _), do: :float


### PR DESCRIPTION
This should not cause any issues as `Absinthe` declares this type in `Absinthe.Type.Custom` same as it is also done for `:datetime`.

Sadly, I've didn't add any tests for it since there were no specific tests for `:datetime` either.
