### PR TITLE
improvement: support manual relationships

### DIFF
--- a/lib/graphql/dataloader.ex
+++ b/lib/graphql/dataloader.ex
@@ -235,17 +235,24 @@ defmodule AshGraphql.Dataloader do
 
         cardinality = relationship.cardinality
 
-        query =
-          query
-          |> Ash.Query.new()
-          |> Ash.Query.set_tenant(tenant)
-          |> Ash.Query.for_read(
-            relationship.read_action ||
-              Ash.Resource.Info.primary_action!(relationship.destination, :read).name,
-            opts[:args]
-          )
+        loads =
+          if Map.has_key?(relationship, :manual) && relationship.manual do
+            field
+          else
+            query =
+              query
+              |> Ash.Query.new()
+              |> Ash.Query.set_tenant(tenant)
+              |> Ash.Query.for_read(
+                relationship.read_action ||
+                  Ash.Resource.Info.primary_action!(relationship.destination, :read).name,
+                opts[:args]
+              )
 
-        loaded = source.api.load!(records, [{field, query}], api_opts || [])
+            {field, query}
+          end
+
+        loaded = source.api.load!(records, [loads], api_opts || [])
 
         loaded =
           case loaded do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -58,6 +58,34 @@ defmodule AfterActionRaiseResourceError do
   end
 end
 
+defmodule RelatedPosts do
+  use Ash.Resource.ManualRelationship
+  require Ash.Query
+
+  def load(posts, _opts, %{api: api}) do
+    posts = api.load!(posts, :tags)
+
+    {
+      :ok,
+      posts
+      |> Enum.map(fn post ->
+        tag_ids =
+          post.tags
+          |> Enum.map(& &1.id)
+
+        other_posts =
+          AshGraphql.Test.Post
+          |> Ash.Query.filter(tags.id in ^tag_ids)
+          |> Ash.Query.filter(id != ^post.id)
+          |> api.read!()
+
+        {post.id, other_posts}
+      end)
+      |> Map.new()
+    }
+  end
+end
+
 defmodule AshGraphql.Test.Post do
   @moduledoc false
 
@@ -317,5 +345,9 @@ defmodule AshGraphql.Test.Post do
       source_attribute_on_join_resource: :post_id,
       destination_attribute_on_join_resource: :tag_id
     )
+
+    has_many :related_posts, AshGraphql.Test.Post do
+      manual(RelatedPosts)
+    end
   end
 end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -59,6 +59,7 @@ defmodule AfterActionRaiseResourceError do
 end
 
 defmodule RelatedPosts do
+  @moduledoc false
   use Ash.Resource.ManualRelationship
   require Ash.Query
 


### PR DESCRIPTION
Prior to this patch, an error was raised `* No such attribute [resource]_id`, since the data loader attempted to load the relationship via a related id field, which does not exist for manual relationships.
