### PR TITLE
feat: add `filterable_fields` to limit generated filters

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -17,6 +17,7 @@ spark_locals_without_parens = [
   encode_primary_key?: 1,
   error_handler: 1,
   field_names: 1,
+  filterable_fields: 1,
   generate_object?: 1,
   get: 2,
   get: 3,

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -129,4 +129,16 @@ defmodule AshGraphql.Resource.Info do
   def generate_object?(resource) do
     Extension.get_opt(resource, [:graphql], :generate_object?, nil)
   end
+
+  @doc "Fields that may be filtered on"
+  def filterable_fields(resource) do
+    Extension.get_opt(resource, [:graphql], :filterable_fields, nil)
+  end
+
+  @doc "May the specified field be filtered on?"
+  def filterable_field?(resource, field) do
+    filterable_fields = AshGraphql.Resource.Info.filterable_fields(resource)
+
+    is_nil(filterable_fields) or field.name in filterable_fields
+  end
 end


### PR DESCRIPTION
Adds the ability to specify which fields a filter should be made available for:

```elixir
graphql do
  filterable_fields [:name, :age]
end
```

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
