### PR TITLE
add tests for graphql aliases

### DIFF
--- a/test/alias_test.exs
+++ b/test/alias_test.exs
@@ -1,0 +1,254 @@
+defmodule AliasTest do
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  setup do
+    on_exit(fn ->
+      AshGraphql.TestHelpers.stop_ets()
+    end)
+  end
+
+  test "attribute alias works correctly for nullable attribute with built-in type" do
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create, text: "foo", published: true, score: 9.8)
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          content: text
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+    assert %{data: %{"getPost" => %{"content" => "foo"}}} = result
+  end
+
+  test "attribute alias works correctly for non-nullable attribute with built-in type" do
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create, text: "foo", published: true, score: 9.8)
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          text: requiredString
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+    assert %{data: %{"getPost" => %{"text" => "test"}}} = result
+  end
+
+  test "attribute alias works correctly for nullable attribute with custom type" do
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create,
+        text: "foo",
+        foo: %{bar: "baz"},
+        published: true,
+        score: 9.8
+      )
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          bar: foo {
+            bar
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+    assert %{data: %{"getPost" => %{"bar" => %{"bar" => "baz"}}}} = result
+  end
+
+  test "attribute alias works correctly for nullable attribute with embedded type" do
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create,
+        text: "foo",
+        embed: %{nested_embed: %{name: "test embed"}},
+        published: true,
+        score: 9.8
+      )
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          embedded: embed {
+            nested_embed {
+              name
+            }
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getPost" => %{"embedded" => %{"nested_embed" => %{"name" => "test embed"}}}
+             }
+           } = result
+  end
+
+  test "calculation alias works correctly" do
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create,
+        text: "foo",
+        text1: "hello",
+        text2: "world",
+        published: true,
+        score: 9.8
+      )
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          content: full_text
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getPost" => %{"content" => "helloworld"}
+             }
+           } = result
+  end
+
+  test "aggregate alias works correctly" do
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create,
+        text: "foo",
+        published: true,
+        score: 9.8
+      )
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          comments: commentCount
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getPost" => %{"comments" => 0}
+             }
+           } = result
+  end
+
+  test "relationship alias works correctly" do
+    author =
+      AshGraphql.Test.User
+      |> Ash.Changeset.for_create(:create, name: "test")
+      |> AshGraphql.Test.Api.create!()
+      |> IO.inspect()
+
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create,
+        text: "foo",
+        published: true,
+        score: 9.8,
+        auhtor_id: author.id
+      )
+      |> AshGraphql.Test.Api.create!()
+
+    resp =
+      """
+      query Post($id: ID!) {
+        getPost(id: $id) {
+          writer: author {
+            name
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "id" => post.id
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    name = author.name
+
+    assert %{
+             data: %{
+               "getPost" => %{"author" => %{"name" => ^name}}
+             }
+           } = result
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -321,6 +321,10 @@ defmodule AshGraphql.Test.Post do
     attribute(:embed_union_unnested, AshGraphql.Types.EmbedUnionNewTypeUnnested)
     attribute(:enum_new_type, AshGraphql.Types.EnumNewType)
     attribute(:string_new_type, AshGraphql.Types.StringNewType)
+    attribute :required_string, :string do
+      allow_nil? false
+      default "test"
+    end
 
     create_timestamp(:created_at, private?: false)
   end
@@ -335,6 +339,10 @@ defmodule AshGraphql.Test.Post do
         default(" ")
       end
     end
+  end
+
+  aggregates do
+    count :comment_count, :comments
   end
 
   relationships do


### PR DESCRIPTION
After working a bit more with aliases today I found a couple more problems, I tried to check the code, but had a hard time figuring out what happened. 

Instead I created a couple tests that should check most alias cases. During this progress the relationship test also gave me this error 

```elixir
13:23:38.112 [warning] `b6c6c824-999f-4f50-96bb-e2be5a7401f3`: AshGraphql.Error not implemented for error:

** (Ash.Error.Framework) Framework Error

* Assumption failed: Invalid return from request resolver for "fetch AshGraphql.Test.Post.read" data:
Got:
:error


This should not be possible, please report a detailed bug at:

https://github.com/ash-project/ash/issues/new?assignees=&labels=bug%2C+needs+review&template=bug_report.md&title=

  (ash 2.9.26) lib/ash/engine/request.ex:1224: Ash.Engine.Request.do_try_resolve_local/4
  (ash 2.9.26) lib/ash/engine/request.ex:282: Ash.Engine.Request.do_next/1
  (ash 2.9.26) lib/ash/engine/request.ex:211: Ash.Engine.Request.next/1
  (ash 2.9.26) lib/ash/engine/engine.ex:712: Ash.Engine.advance_request/2
  (ash 2.9.26) lib/ash/engine/engine.ex:637: Ash.Engine.fully_advance_request/2
  (ash 2.9.26) lib/ash/engine/engine.ex:578: Ash.Engine.do_run_iteration/2
  (elixir 1.14.3) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
  (ash 2.9.26) lib/ash/engine/engine.ex:307: Ash.Engine.run_to_completion/1
  (ash 2.9.26) lib/ash/engine/engine.ex:252: Ash.Engine.do_run/2
  (ash 2.9.26) lib/ash/engine/engine.ex:148: Ash.Engine.run/2
  (ash 2.9.26) lib/ash/actions/read.ex:173: Ash.Actions.Read.do_run/3
  (ash 2.9.26) lib/ash/actions/read.ex:96: Ash.Actions.Read.run/3
  (ash 2.9.26) lib/ash/api/api.ex:1837: Ash.Api.read_one/3
  (ash_graphql 0.25.8) test/support/api.ex:1: AshGraphql.Test.Api.read_one/2
  (ash_graphql 0.25.8) lib/graphql/resolver.ex:82: AshGraphql.Graphql.Resolver.resolve/2
  (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:232: Absinthe.Phase.Document.Execution.Resolution.reduce_resolution/1
  (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:187: Absinthe.Phase.Document.Execution.Resolution.do_resolve_field/3
  (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:172: Absinthe.Phase.Document.Execution.Resolution.do_resolve_fields/6
    (ash 2.9.26) lib/ash/error/error.ex:461: Ash.Error.choose_error/2
    (ash 2.9.26) lib/ash/error/error.ex:218: Ash.Error.to_error_class/2
    (ash 2.9.26) lib/ash/actions/read.ex:184: Ash.Actions.Read.do_run/3
    (ash 2.9.26) lib/ash/actions/read.ex:96: Ash.Actions.Read.run/3
    (ash 2.9.26) lib/ash/api/api.ex:1837: Ash.Api.read_one/3
    (ash_graphql 0.25.8) test/support/api.ex:1: AshGraphql.Test.Api.read_one/2
    (ash_graphql 0.25.8) lib/graphql/resolver.ex:82: AshGraphql.Graphql.Resolver.resolve/2
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:232: Absinthe.Phase.Document.Execution.Resolution.reduce_resolution/1
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:187: Absinthe.Phase.Document.Execution.Resolution.do_resolve_field/3
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:172: Absinthe.Phase.Document.Execution.Resolution.do_resolve_fields/6
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:143: Absinthe.Phase.Document.Execution.Resolution.resolve_fields/4
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:88: Absinthe.Phase.Document.Execution.Resolution.walk_result/5
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:67: Absinthe.Phase.Document.Execution.Resolution.perform_resolution/3
    (absinthe 1.7.1) lib/absinthe/phase/document/execution/resolution.ex:24: Absinthe.Phase.Document.Execution.Resolution.resolve_current/3
    (absinthe 1.7.1) lib/absinthe/pipeline.ex:405: Absinthe.Pipeline.run_phase/3
    (absinthe 1.7.1) lib/absinthe.ex:116: Absinthe.run/3
    test/alias_test.exs:236: AliasTest."test relationship alias works correctly"/1
    (ex_unit 1.14.3) lib/ex_unit/runner.ex:512: ExUnit.Runner.exec_test/1
```
