### PR TITLE
fix: fix Logger deprecations for elixir 1.15

### DIFF
--- a/lib/graphql/errors.ex
+++ b/lib/graphql/errors.ex
@@ -27,17 +27,17 @@ defmodule AshGraphql.Errors do
         if is_exception(error) do
           case error do
             %{stacktrace: %{stacktrace: stacktrace}} ->
-              Logger.warn(
+              Logger.warning(
                 "`#{uuid}`: AshGraphql.Error not implemented for error:\n\n#{Exception.format(:error, error, stacktrace)}"
               )
 
             error ->
-              Logger.warn(
+              Logger.warning(
                 "`#{uuid}`: AshGraphql.Error not implemented for error:\n\n#{Exception.format(:error, error)}"
               )
           end
         else
-          Logger.warn(
+          Logger.warning(
             "`#{uuid}`: AshGraphql.Error not implemented for error:\n\n#{inspect(error)}"
           )
         end

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -2347,7 +2347,7 @@ defmodule AshGraphql.Graphql.Resolver do
                nil
            end
 
-         Logger.warn(
+         Logger.warning(
            "`#{uuid}`: AshGraphql.Error not implemented for error:\n\n#{Exception.format(:error, error, stacktrace)}"
          )
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -8,7 +8,10 @@ defmodule AshGraphql.TestHelpers do
         Ash.DataLayer.Ets.stop(resource)
       rescue
         error ->
-          Logger.warn("Error while stopping storage for #{inspect(resource)}: #{inspect(error)}")
+          Logger.warning(
+            "Error while stopping storage for #{inspect(resource)}: #{inspect(error)}"
+          )
+
           :ok
       end
     end


### PR DESCRIPTION
Use Logger.warning instead of Logger.warn, [which is deprecated as of elixir 1.15](https://github.com/elixir-lang/elixir/blob/v1.15/CHANGELOG.md#logger-2).

Logger.warning [is available since elixir 1.11](https://hexdocs.pm/logger/1.15.0/Logger.html#warning/2), and since [this project requires at least elixir 1.11](https://github.com/ash-project/ash_graphql/blob/main/mix.exs#L14), this is a safe change.