### PR TITLE
reproduce fragment issue

### DIFF
--- a/test/read_test.exs
+++ b/test/read_test.exs
@@ -188,6 +188,73 @@ defmodule AshGraphql.ReadTest do
              result
   end
 
+  test "loading relationships with fragment works" do
+    user =
+      AshGraphql.Test.User
+      |> Ash.Changeset.for_create(:create, %{name: "fred"})
+      |> AshGraphql.Test.Api.create!()
+
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(
+        :create,
+        %{
+          author_id: user.id,
+          text: "a",
+          published: true
+        }
+      )
+      |> AshGraphql.Test.Api.create!()
+
+    post
+    |> Ash.Changeset.for_update(
+      :update_with_comments,
+      %{
+        comments: [%{text: "comment", author_id: user.id}]
+      }
+    )
+    |> AshGraphql.Test.Api.update!()
+
+    resp =
+      """
+      query postLibrary {
+        postLibrary(sort: {field: TEXT}) {
+          id
+          comments {
+            ...User
+          }
+        }
+      }
+
+      fragment User on Comment {
+        id
+        author {
+          name
+        }
+      }
+
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "postLibrary" => [
+                 %{
+                   "comments" => [
+                     %{
+                       "author" => %{"name" => "fred"}
+                     }
+                   ]
+                 }
+               ]
+             }
+           } = result
+  end
+
   test "the same relationship can be fetched with different parameters" do
     post =
       AshGraphql.Test.Post


### PR DESCRIPTION
I was now able to reproduce the issue with the fragment. The fragment needed to be on a lower level in the query and the related resource was not allowed to be queried further up.

At the [top](https://github.com/ash-project/ash_graphql/blob/c70e7dec7dac1aac7fd40a67b51a6d61d67f9d41/lib/graphql/resolver.ex#L50), the the name in the resolution is the name of the fragment, so the relationship source_attribute is not picked up there. Further [down](https://github.com/ash-project/ash_graphql/blob/c70e7dec7dac1aac7fd40a67b51a6d61d67f9d41/lib/graphql/resolver.ex#L1588) the relationship is picked up from the selection.schema_node.identifier but the source attribute is not available on the related resource I guess. 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
