### PR TITLE
test: add failing test for an aggregate of a calculation

### DIFF
--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -38,6 +38,16 @@ defmodule AshGraphql.Test.Comment do
       writable?(false)
       default(:comment)
     end
+
+    create_timestamp(:created_at)
+  end
+
+  calculations do
+    calculate(
+      :timestamp,
+      :utc_datetime_usec,
+      expr(created_at)
+    )
   end
 
   relationships do

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -365,6 +365,7 @@ defmodule AshGraphql.Test.Post do
 
   aggregates do
     count(:comment_count, :comments)
+    max(:latest_comment_at, [:comments], :timestamp)
   end
 
   relationships do


### PR DESCRIPTION
An error occurs at compile time when an aggregate of a calculation is defined:

```
== Compilation error in file test/support/schema.ex == ** (MatchError) no match of right hand side value: {:error, "Must provide field type for max"}
    lib/resource/resource.ex:2278: AshGraphql.Resource.filterable?/2
    (elixir 1.15.4) lib/enum.ex:4265: Enum.filter_list/2
    (elixir 1.15.4) lib/enum.ex:4266: Enum.filter_list/2
    lib/resource/resource.ex:2229: AshGraphql.Resource.aggregate_filter_fields/2
    lib/resource/resource.ex:2195: AshGraphql.Resource.resource_filter_fields/2
    lib/resource/resource.ex:1159: AshGraphql.Resource.args/5
    lib/resource/resource.ex:425: anonymous fn/6 in AshGraphql.Resource.queries/5
    (elixir 1.15.4) lib/enum.ex:1693: Enum."-map/2-lists^map/1-1-"/2
```