### PR TITLE
refactor: make the node in relay edges non-null

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3134,7 +3134,9 @@ defmodule AshGraphql.Resource do
                   name: "edges",
                   __reference__: ref(__ENV__),
                   type: %Absinthe.Blueprint.TypeReference.List{
-                    of_type: String.to_atom("#{type}_edge")
+                    of_type: %Absinthe.Blueprint.TypeReference.List{
+                      of_type: String.to_atom("#{type}_edge")
+                    }
                   }
                 }
               ]

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3134,7 +3134,7 @@ defmodule AshGraphql.Resource do
                   name: "edges",
                   __reference__: ref(__ENV__),
                   type: %Absinthe.Blueprint.TypeReference.List{
-                    of_type: %Absinthe.Blueprint.TypeReference.List{
+                    of_type: %Absinthe.Blueprint.TypeReference.NonNull{
                       of_type: String.to_atom("#{type}_edge")
                     }
                   }

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3103,7 +3103,9 @@ defmodule AshGraphql.Resource do
                 module: schema,
                 name: "node",
                 __reference__: ref(__ENV__),
-                type: type
+                type: %Absinthe.Blueprint.TypeReference.NonNull{
+                  of_type: type
+                }
               }
             ],
             identifier: String.to_atom("#{type}_edge"),


### PR DESCRIPTION
I had to do some front-end work today and felt like this would be better. The spec doesn't say if it has to be nullable or non-nullable. Same with the Edge, I don't think it would make sense to have null values as edges. 

I couldn't think of a situation where we would actually return null for a node, pls correct me if I'm wrong. 