### PR TITLE
Relay refetching support

### DIFF
--- a/documentation/topics/relay.md
+++ b/documentation/topics/relay.md
@@ -14,3 +14,14 @@ Use the following option when calling `use AshGraphql`
 ```elixir
 use AshGraphql, define_relay_types?: false
 ```
+
+## Relay Global IDs
+
+Use the following option to generate Relay Global IDs (see
+[here](https://relay.dev/graphql/objectidentification.htm)).
+
+```elixir
+use AshGraphql, relay_ids?: true
+```
+
+This allows refetching a node using the `node` query and passing its global ID.

--- a/lib/api/api.ex
+++ b/lib/api/api.ex
@@ -72,28 +72,33 @@ defmodule AshGraphql.Api do
   defdelegate debug?(api), to: AshGraphql.Api.Info
 
   @doc false
-  def queries(api, resources, action_middleware, schema) do
-    Enum.flat_map(resources, &AshGraphql.Resource.queries(api, &1, action_middleware, schema))
+  def queries(api, resources, action_middleware, schema, relay_ids?) do
+    Enum.flat_map(
+      resources,
+      &AshGraphql.Resource.queries(api, &1, action_middleware, schema, relay_ids?)
+    )
   end
 
   @doc false
-  def mutations(api, resources, action_middleware, schema) do
+  def mutations(api, resources, action_middleware, schema, relay_ids?) do
     resources
     |> Enum.filter(fn resource ->
       AshGraphql.Resource in Spark.extensions(resource)
     end)
-    |> Enum.flat_map(&AshGraphql.Resource.mutations(api, &1, action_middleware, schema))
+    |> Enum.flat_map(
+      &AshGraphql.Resource.mutations(api, &1, action_middleware, schema, relay_ids?)
+    )
   end
 
   @doc false
-  def type_definitions(api, resources, schema, env, first?, define_relay_types?) do
+  def type_definitions(api, resources, schema, env, first?, define_relay_types?, relay_ids?) do
     resource_types =
       resources
       |> Enum.reject(&Ash.Resource.Info.embedded?/1)
       |> Enum.flat_map(fn resource ->
         if AshGraphql.Resource in Spark.extensions(resource) &&
              AshGraphql.Resource.Info.type(resource) do
-          AshGraphql.Resource.type_definitions(resource, api, schema) ++
+          AshGraphql.Resource.type_definitions(resource, api, schema, relay_ids?) ++
             AshGraphql.Resource.mutation_types(resource, schema)
         else
           AshGraphql.Resource.no_graphql_types(resource, schema)

--- a/lib/api/api.ex
+++ b/lib/api/api.ex
@@ -123,6 +123,7 @@ defmodule AshGraphql.Api do
                 }
               ],
               identifier: :node,
+              resolve_type: &AshGraphql.Graphql.Resolver.resolve_node_type/2,
               __reference__: AshGraphql.Resource.ref(env),
               module: schema
             },

--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -36,7 +36,8 @@ defmodule AshGraphql do
             apis: opts[:apis],
             api: opts[:api],
             action_middleware: opts[:action_middleware] || [],
-            define_relay_types?: Keyword.get(opts, :define_relay_types?, true)
+            define_relay_types?: Keyword.get(opts, :define_relay_types?, true),
+            relay_ids?: Keyword.get(opts, :relay_ids?, false)
           ],
           generated: true do
       require Ash.Api.Info
@@ -138,14 +139,24 @@ defmodule AshGraphql do
 
             blueprint_with_queries =
               api
-              |> AshGraphql.Api.queries(unquote(resources), action_middleware, __MODULE__)
+              |> AshGraphql.Api.queries(
+                unquote(resources),
+                action_middleware,
+                __MODULE__,
+                unquote(relay_ids?)
+              )
               |> Enum.reduce(blueprint, fn query, blueprint ->
                 Absinthe.Blueprint.add_field(blueprint, "RootQueryType", query)
               end)
 
             blueprint_with_mutations =
               api
-              |> AshGraphql.Api.mutations(unquote(resources), action_middleware, __MODULE__)
+              |> AshGraphql.Api.mutations(
+                unquote(resources),
+                action_middleware,
+                __MODULE__,
+                unquote(relay_ids?)
+              )
               |> Enum.reduce(blueprint_with_queries, fn mutation, blueprint ->
                 Absinthe.Blueprint.add_field(blueprint, "RootMutationType", mutation)
               end)
@@ -155,7 +166,11 @@ defmodule AshGraphql do
                 apis = unquote(Enum.map(apis, &elem(&1, 0)))
 
                 embedded_types =
-                  AshGraphql.get_embedded_types(unquote(ash_resources), unquote(schema))
+                  AshGraphql.get_embedded_types(
+                    unquote(ash_resources),
+                    unquote(schema),
+                    unquote(relay_ids?)
+                  )
 
                 global_enums =
                   AshGraphql.global_enums(unquote(ash_resources), unquote(schema), __ENV__)
@@ -171,7 +186,8 @@ defmodule AshGraphql do
                       unquote(schema),
                       __ENV__,
                       true,
-                      unquote(define_relay_types?)
+                      unquote(define_relay_types?),
+                      unquote(relay_ids?)
                     ) ++
                     global_enums ++
                     global_unions ++
@@ -185,7 +201,8 @@ defmodule AshGraphql do
                   unquote(schema),
                   __ENV__,
                   false,
-                  false
+                  false,
+                  unquote(relay_ids?)
                 )
               end
 
@@ -491,7 +508,7 @@ defmodule AshGraphql do
   end
 
   # sobelow_skip ["DOS.BinToAtom"]
-  def get_embedded_types(all_resources, schema) do
+  def get_embedded_types(all_resources, schema, relay_ids?) do
     all_resources
     |> Enum.flat_map(fn resource ->
       resource
@@ -566,7 +583,8 @@ defmodule AshGraphql do
           AshGraphql.Resource.type_definition(
             embedded_type,
             Module.concat(embedded_type, ShadowApi),
-            schema
+            schema,
+            relay_ids?
           ),
           AshGraphql.Resource.embedded_type_input(
             source_resource,

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -141,3 +141,15 @@ defimpl AshGraphql.Error, for: Ash.Error.Forbidden.ForbiddenField do
     }
   end
 end
+
+defimpl AshGraphql.Error, for: Ash.Error.Invalid.InvalidPrimaryKey do
+  def to_error(error) do
+    %{
+      message: "invalid primary key provided",
+      short_message: "invalid primary key provided",
+      fields: [],
+      vars: Map.new(error.vars),
+      code: Ash.ErrorKind.code(error)
+    }
+  end
+end

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -2543,6 +2543,10 @@ defmodule AshGraphql.Graphql.Resolver do
     child_complexity + 1
   end
 
+  def resolve_node_type(%resource{}, _) do
+    AshGraphql.Resource.Info.type(resource)
+  end
+
   defp apply_load_arguments(arguments, query, will_paginate? \\ false) do
     Enum.reduce(arguments, query, fn
       {:limit, limit}, query when not will_paginate? ->

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -135,6 +135,7 @@ defmodule AshGraphql.Graphql.Resolver do
            type: :get,
            action: action,
            identity: identity,
+           type_name: type_name,
            modify_resolution: modify
          } = gql_query, relay_ids?}
       ) do
@@ -173,7 +174,7 @@ defmodule AshGraphql.Graphql.Resolver do
             |> Ash.Query.set_tenant(Map.get(context, :tenant))
             |> Ash.Query.set_context(get_context(context))
             |> set_query_arguments(action, arguments)
-            |> select_fields(resource, resolution)
+            |> select_fields(resource, resolution, type_name)
 
           {result, modify_args} =
             case filter do
@@ -212,7 +213,7 @@ defmodule AshGraphql.Graphql.Resolver do
                   |> Ash.Query.set_tenant(Map.get(context, :tenant))
                   |> Ash.Query.set_context(get_context(context))
                   |> set_query_arguments(action, arguments)
-                  |> select_fields(resource, resolution)
+                  |> select_fields(resource, resolution, type_name)
                   |> load_fields(
                     [
                       api: api,
@@ -278,7 +279,13 @@ defmodule AshGraphql.Graphql.Resolver do
   def resolve(
         %{arguments: args, context: context} = resolution,
         {api, resource,
-         %{name: query_name, type: :read_one, action: action, modify_resolution: modify} =
+         %{
+           name: query_name,
+           type: :read_one,
+           action: action,
+           modify_resolution: modify,
+           type_name: type_name
+         } =
            gql_query, _relay_ids?}
       ) do
     metadata = %{
@@ -313,7 +320,7 @@ defmodule AshGraphql.Graphql.Resolver do
           |> Ash.Query.set_tenant(Map.get(context, :tenant))
           |> Ash.Query.set_context(get_context(context))
           |> set_query_arguments(action, args)
-          |> select_fields(resource, resolution)
+          |> select_fields(resource, resolution, type_name)
           |> load_fields(
             [
               api: api,
@@ -371,6 +378,7 @@ defmodule AshGraphql.Graphql.Resolver do
            type: :list,
            relay?: relay?,
            action: action,
+           type_name: type_name,
            modify_resolution: modify
          } = gql_query, _relay_ids?}
       ) do
@@ -405,14 +413,15 @@ defmodule AshGraphql.Graphql.Resolver do
           query = apply_load_arguments(args, Ash.Query.new(resource), true)
 
           {result, modify_args} =
-            with {:ok, opts} <- validate_resolve_opts(resolution, pagination, opts, args),
+            with {:ok, opts} <-
+                   validate_resolve_opts(resolution, resource, pagination, relay?, opts, args),
                  result_fields <- get_result_fields(pagination, relay?),
                  initial_query <-
                    query
                    |> Ash.Query.set_tenant(Map.get(context, :tenant))
                    |> Ash.Query.set_context(get_context(context))
                    |> set_query_arguments(action, args)
-                   |> select_fields(resource, resolution, result_fields),
+                   |> select_fields(resource, resolution, type_name, result_fields),
                  query <-
                    load_fields(
                      initial_query,
@@ -727,7 +736,7 @@ defmodule AshGraphql.Graphql.Resolver do
     end
   end
 
-  def validate_resolve_opts(resolution, pagination, opts, args) do
+  def validate_resolve_opts(resolution, resource, pagination, relay?, opts, args) do
     if pagination && (pagination.offset? || pagination.keyset?) do
       with page_opts <-
              args
@@ -735,7 +744,8 @@ defmodule AshGraphql.Graphql.Resolver do
              |> Enum.reject(fn {_, val} -> is_nil(val) end),
            {:ok, page_opts} <- validate_offset_opts(page_opts, pagination),
            {:ok, page_opts} <- validate_keyset_opts(page_opts, pagination) do
-        field_names = resolution |> fields([]) |> names_only()
+        type = page_type(resource, pagination, relay?)
+        field_names = resolution |> fields([], type) |> names_only()
 
         page =
           if Enum.any?(field_names, &(&1 == :count)) do
@@ -1029,6 +1039,8 @@ defmodule AshGraphql.Graphql.Resolver do
               opts
             end
 
+          type_name = mutation_result_type(mutation_name)
+
           changeset =
             resource
             |> Ash.Changeset.new()
@@ -1038,7 +1050,7 @@ defmodule AshGraphql.Graphql.Resolver do
               actor: Map.get(context, :actor),
               authorize?: AshGraphql.Api.Info.authorize?(api)
             )
-            |> select_fields(resource, resolution, ["result"])
+            |> select_fields(resource, resolution, type_name, ["result"])
             |> load_fields(
               [
                 api: api,
@@ -1174,6 +1186,8 @@ defmodule AshGraphql.Graphql.Resolver do
                     tenant: Map.get(context, :tenant)
                   ]
 
+                  type_name = mutation_result_type(mutation_name)
+
                   changeset =
                     initial
                     |> Ash.Changeset.new()
@@ -1183,7 +1197,7 @@ defmodule AshGraphql.Graphql.Resolver do
                       actor: Map.get(context, :actor),
                       authorize?: AshGraphql.Api.Info.authorize?(api)
                     )
-                    |> select_fields(resource, resolution, ["result"])
+                    |> select_fields(resource, resolution, type_name, ["result"])
                     |> load_fields(
                       [
                         api: api,
@@ -1334,6 +1348,8 @@ defmodule AshGraphql.Graphql.Resolver do
                     tenant: Map.get(context, :tenant)
                   ]
 
+                  type_name = mutation_result_type(mutation_name)
+
                   changeset =
                     initial
                     |> Ash.Changeset.new()
@@ -1343,7 +1359,7 @@ defmodule AshGraphql.Graphql.Resolver do
                       actor: Map.get(context, :actor),
                       authorize?: AshGraphql.Api.Info.authorize?(api)
                     )
-                    |> select_fields(resource, resolution, ["result"])
+                    |> select_fields(resource, resolution, type_name, ["result"])
 
                   {result, modify_args} =
                     changeset
@@ -1535,8 +1551,10 @@ defmodule AshGraphql.Graphql.Resolver do
   defp clear_fields(nil, _, _), do: nil
 
   defp clear_fields(result, resource, resolution) do
+    type = AshGraphql.Resource.Info.type(resource)
+
     resolution
-    |> fields(["result"])
+    |> fields(["result"], type)
     |> names_only()
     |> Enum.map(fn identifier ->
       Ash.Resource.Info.aggregate(resource, identifier)
@@ -1758,6 +1776,7 @@ defmodule AshGraphql.Graphql.Resolver do
             |> select_fields(
               relationship.destination,
               resolution,
+              nil,
               Enum.map(Enum.reverse([selection | path]), & &1.name)
             )
             |> load_fields(
@@ -2087,11 +2106,32 @@ defmodule AshGraphql.Graphql.Resolver do
     end
   end
 
+  defp mutation_result_type(mutation_name) do
+    String.to_atom("#{mutation_name}_result")
+  end
+
+  defp page_type(resource, pagination, relay?) do
+    type = AshGraphql.Resource.Info.type(resource)
+
+    cond do
+      relay? ->
+        String.to_atom("#{type}_connection")
+
+      pagination.keyset? ->
+        String.to_atom("keyset_page_of_#{type}")
+
+      pagination.offset? ->
+        String.to_atom("page_of_#{type}")
+    end
+  end
+
   @doc false
-  def select_fields(query_or_changeset, resource, resolution, nested \\ []) do
+  def select_fields(query_or_changeset, resource, resolution, type_override, nested \\ []) do
+    type = type_override || AshGraphql.Resource.Info.type(resource)
+
     subfields =
       resolution
-      |> fields(nested)
+      |> fields(nested, type)
       |> names_only()
       |> Enum.map(&field_or_relationship(resource, &1))
       |> Enum.filter(& &1)
@@ -2122,12 +2162,15 @@ defmodule AshGraphql.Graphql.Resolver do
     end
   end
 
-  defp fields(%Absinthe.Resolution{} = resolution, []) do
+  defp fields(%Absinthe.Resolution{} = resolution, [], type) do
     resolution
-    |> Absinthe.Resolution.project()
+    |> Absinthe.Resolution.project(type)
   end
 
-  defp fields(%Absinthe.Resolution{} = resolution, names) do
+  defp fields(%Absinthe.Resolution{} = resolution, names, _type) do
+    # Here we don't pass the type to project because the Enum.reduce below already
+    # takes care of projecting the nested fields using the correct type
+
     project =
       resolution
       |> Absinthe.Resolution.project()

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -442,7 +442,7 @@ defmodule AshGraphql.Resource do
           decode_primary_key(resource, primary_key)
 
         _ ->
-          {:error, "Invalid primary key"}
+          {:error, Ash.Error.Invalid.InvalidPrimaryKey.exception(resource: resource, value: id)}
       end
     else
       decode_primary_key(resource, id)
@@ -477,7 +477,7 @@ defmodule AshGraphql.Resource do
     {:ok, {type, primary_key}}
   rescue
     _ ->
-      {:error, "Invalid primary key"}
+      {:error, Ash.Error.Invalid.InvalidPrimaryKey.exception(resource: nil, value: id)}
   end
 
   @doc false

--- a/lib/subscriptions.ex
+++ b/lib/subscriptions.ex
@@ -14,7 +14,7 @@ defmodule AshGraphql.Subscription do
     query
     |> Ash.Query.set_tenant(Map.get(context, :tenant))
     |> Ash.Query.set_context(get_context(context))
-    |> AshGraphql.Graphql.Resolver.select_fields(query.resource, resolution)
+    |> AshGraphql.Graphql.Resolver.select_fields(query.resource, resolution, nil)
     |> AshGraphql.Graphql.Resolver.load_fields(
       [
         api: api,

--- a/test/relay_ids_test.exs
+++ b/test/relay_ids_test.exs
@@ -79,7 +79,7 @@ defmodule AshGraphql.RelayIdsTest do
         )
 
       assert {:ok, result} = resp
-      assert result[:errors] != nil
+      assert [%{code: "invalid_primary_key"}] = result[:errors]
     end
 
     test "returns error on ID for wrong resource" do
@@ -105,7 +105,7 @@ defmodule AshGraphql.RelayIdsTest do
         )
 
       assert {:ok, result} = resp
-      assert result[:errors] != nil
+      assert [%{code: "invalid_primary_key"}] = result[:errors]
     end
   end
 end

--- a/test/relay_ids_test.exs
+++ b/test/relay_ids_test.exs
@@ -1,0 +1,111 @@
+defmodule AshGraphql.RelayIdsTest do
+  use ExUnit.Case, async: false
+
+  alias AshGraphql.Test.RelayIds.{Api, Post, Schema, User}
+
+  setup do
+    on_exit(fn ->
+      AshGraphql.TestHelpers.stop_ets()
+    end)
+  end
+
+  describe "relay global ID" do
+    test "can be used in get queries and is exposed correctly in relationships" do
+      user =
+        User
+        |> Ash.Changeset.for_create(:create, %{name: "fred"})
+        |> Api.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            author_id: user.id,
+            text: "foo",
+            published: true
+          }
+        )
+        |> Api.create!()
+
+      user_relay_id = AshGraphql.Resource.encode_relay_id(user)
+      post_relay_id = AshGraphql.Resource.encode_relay_id(post)
+
+      resp =
+        """
+          query GetPost($id: ID!) {
+          getPost(id: $id) {
+            text
+            author {
+              id
+              name
+            }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => post_relay_id
+          }
+        )
+
+      assert {:ok, result} = resp
+
+      refute Map.has_key?(result, :errors)
+
+      assert %{
+               data: %{
+                 "getPost" => %{
+                   "text" => "foo",
+                   "author" => %{"id" => ^user_relay_id, "name" => "fred"}
+                 }
+               }
+             } = result
+    end
+
+    test "returns error on invalid ID" do
+      resp =
+        """
+          query GetPost($id: ID!) {
+          getPost(id: $id) {
+            text
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => "invalid"
+          }
+        )
+
+      assert {:ok, result} = resp
+      assert result[:errors] != nil
+    end
+
+    test "returns error on ID for wrong resource" do
+      user =
+        User
+        |> Ash.Changeset.for_create(:create, %{name: "fred"})
+        |> Api.create!()
+
+      user_relay_id = AshGraphql.Resource.encode_relay_id(user)
+
+      resp =
+        """
+          query GetPost($id: ID!) {
+          getPost(id: $id) {
+            text
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => user_relay_id
+          }
+        )
+
+      assert {:ok, result} = resp
+      assert result[:errors] != nil
+    end
+  end
+end

--- a/test/relay_ids_test.exs
+++ b/test/relay_ids_test.exs
@@ -1,7 +1,7 @@
 defmodule AshGraphql.RelayIdsTest do
   use ExUnit.Case, async: false
 
-  alias AshGraphql.Test.RelayIds.{Api, Post, Schema, User}
+  alias AshGraphql.Test.RelayIds.{Api, Post, ResourceWithNoPrimaryKeyGet, Schema, User}
 
   setup do
     on_exit(fn ->
@@ -106,6 +106,123 @@ defmodule AshGraphql.RelayIdsTest do
 
       assert {:ok, result} = resp
       assert [%{code: "invalid_primary_key"}] = result[:errors]
+    end
+  end
+
+  describe "node interface and query" do
+    test "allows retrieving resources" do
+      user =
+        User
+        |> Ash.Changeset.for_create(:create, %{name: "fred"})
+        |> Api.create!()
+
+      post =
+        Post
+        |> Ash.Changeset.for_create(
+          :create,
+          %{
+            author_id: user.id,
+            text: "foo",
+            published: true
+          }
+        )
+        |> Api.create!()
+
+      user_relay_id = AshGraphql.Resource.encode_relay_id(user)
+      post_relay_id = AshGraphql.Resource.encode_relay_id(post)
+
+      document =
+        """
+          query Node($id: ID!) {
+          node(id: $id) {
+            __typename
+
+            ... on User {
+              name
+            }
+
+            ... on Post {
+              text
+            }
+          }
+        }
+        """
+
+      resp =
+        document
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => post_relay_id
+          }
+        )
+
+      assert {:ok, result} = resp
+
+      refute Map.has_key?(result, :errors)
+
+      assert %{
+               data: %{
+                 "node" => %{
+                   "__typename" => "Post",
+                   "text" => "foo"
+                 }
+               }
+             } = result
+
+      resp =
+        document
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => user_relay_id
+          }
+        )
+
+      assert {:ok, result} = resp
+
+      refute Map.has_key?(result, :errors)
+
+      assert %{
+               data: %{
+                 "node" => %{
+                   "__typename" => "User",
+                   "name" => "fred"
+                 }
+               }
+             } = result
+    end
+
+    test "return an error for resources without a primary key get" do
+      resource =
+        ResourceWithNoPrimaryKeyGet
+        |> Ash.Changeset.for_create(:create, %{name: "foo"})
+        |> Api.create!()
+
+      document =
+        """
+          query Node($id: ID!) {
+          node(id: $id) {
+            __typename
+
+            ... on ResourceWithNoPrimaryKeyGet{
+              name
+            }
+          }
+        }
+        """
+
+      resource_relay_id = AshGraphql.Resource.encode_relay_id(resource)
+
+      resp =
+        document
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => resource_relay_id
+          }
+        )
+
+      assert {:ok, result} = resp
+
+      assert result[:errors] != nil
     end
   end
 end

--- a/test/support/relay_ids/api.ex
+++ b/test/support/relay_ids/api.ex
@@ -1,0 +1,13 @@
+defmodule AshGraphql.Test.RelayIds.Api do
+  @moduledoc false
+
+  use Ash.Api,
+    extensions: [
+      AshGraphql.Api
+    ],
+    otp_app: :ash_graphql
+
+  resources do
+    registry(AshGraphql.Test.RelayIds.Registry)
+  end
+end

--- a/test/support/relay_ids/registry.ex
+++ b/test/support/relay_ids/registry.ex
@@ -4,6 +4,7 @@ defmodule AshGraphql.Test.RelayIds.Registry do
 
   entries do
     entry(AshGraphql.Test.RelayIds.Post)
+    entry(AshGraphql.Test.RelayIds.ResourceWithNoPrimaryKeyGet)
     entry(AshGraphql.Test.RelayIds.User)
   end
 end

--- a/test/support/relay_ids/registry.ex
+++ b/test/support/relay_ids/registry.ex
@@ -1,0 +1,9 @@
+defmodule AshGraphql.Test.RelayIds.Registry do
+  @moduledoc false
+  use Ash.Registry
+
+  entries do
+    entry(AshGraphql.Test.RelayIds.Post)
+    entry(AshGraphql.Test.RelayIds.User)
+  end
+end

--- a/test/support/relay_ids/resources/post.ex
+++ b/test/support/relay_ids/resources/post.ex
@@ -1,0 +1,46 @@
+defmodule AshGraphql.Test.RelayIds.Post do
+  @moduledoc false
+
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  require Ash.Query
+
+  graphql do
+    type :post
+
+    queries do
+      get :get_post, :read
+      list :post_library, :read
+    end
+
+    mutations do
+      create :simple_create_post, :create
+      update :update_post, :update
+      destroy :delete_post, :destroy
+    end
+  end
+
+  actions do
+    defaults([:update, :read, :destroy])
+
+    create :create do
+      primary?(true)
+      argument(:author_id, :uuid)
+
+      change(set_attribute(:author_id, arg(:author_id)))
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:text, :string)
+  end
+
+  relationships do
+    belongs_to(:author, AshGraphql.Test.RelayIds.User) do
+      attribute_writable?(true)
+    end
+  end
+end

--- a/test/support/relay_ids/resources/resource_with_no_primary_key_get.ex
+++ b/test/support/relay_ids/resources/resource_with_no_primary_key_get.ex
@@ -1,4 +1,4 @@
-defmodule AshGraphql.Test.RelayIds.User do
+defmodule AshGraphql.Test.RelayIds.ResourceWithNoPrimaryKeyGet do
   @moduledoc false
 
   use Ash.Resource,
@@ -6,24 +6,30 @@ defmodule AshGraphql.Test.RelayIds.User do
     extensions: [AshGraphql.Resource]
 
   graphql do
-    type :user
+    type :resource_with_no_primary_key_get
 
     queries do
-      get :get_user, :read
+      get :get_resource_by_name, :get_by_name
     end
 
     mutations do
-      create :create_user, :create
+      create :create_resource, :create
     end
   end
 
   actions do
     defaults([:create, :update, :destroy, :read])
+
+    read(:get_by_name, get_by: :name)
   end
 
   attributes do
     uuid_primary_key(:id)
-    attribute(:name, :string)
+    attribute(:name, :string, allow_nil?: false)
+  end
+
+  identities do
+    identity(:name, [:name], pre_check_with: AshGraphql.Test.RelayIds.Api)
   end
 
   relationships do

--- a/test/support/relay_ids/resources/user.ex
+++ b/test/support/relay_ids/resources/user.ex
@@ -1,0 +1,28 @@
+defmodule AshGraphql.Test.RelayIds.User do
+  @moduledoc false
+
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type :user
+
+    mutations do
+      create :create_user, :create
+    end
+  end
+
+  actions do
+    defaults([:create, :update, :destroy, :read])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:name, :string)
+  end
+
+  relationships do
+    has_many(:posts, AshGraphql.Test.RelayIds.Post, destination_attribute: :author_id)
+  end
+end

--- a/test/support/relay_ids/schema.ex
+++ b/test/support/relay_ids/schema.ex
@@ -1,0 +1,30 @@
+defmodule AshGraphql.Test.RelayIds.Schema do
+  @moduledoc false
+
+  use Absinthe.Schema
+
+  @apis [AshGraphql.Test.RelayIds.Api]
+
+  use AshGraphql, apis: @apis, relay_ids?: true
+
+  query do
+  end
+
+  mutation do
+  end
+
+  object :foo do
+    field(:foo, :string)
+    field(:bar, :string)
+  end
+
+  input_object :foo_input do
+    field(:foo, non_null(:string))
+    field(:bar, non_null(:string))
+  end
+
+  enum :status do
+    value(:open, description: "The post is open")
+    value(:closed, description: "The post is closed")
+  end
+end


### PR DESCRIPTION
Add support for Relay global IDs and the `node` query, see https://relay.dev/graphql/objectidentification.htm

### Contributor checklist

- [x] Features include unit/acceptance tests
