### PR TITLE
improvement: return a map from decode_relay_id/1

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -2588,7 +2588,7 @@ defmodule AshGraphql.Graphql.Resolver do
 
   def resolve_node(%{arguments: %{id: id}} = resolution, type_to_api_and_resource_map) do
     case AshGraphql.Resource.decode_relay_id(id) do
-      {:ok, {type, primary_key}} ->
+      {:ok, %{type: type, id: primary_key}} ->
         {api, resource} = Map.fetch!(type_to_api_and_resource_map, type)
         # We can be sure this returns something since we check this at compile time
         query = AshGraphql.Resource.primary_key_get_query(resource)

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -438,7 +438,7 @@ defmodule AshGraphql.Resource do
 
     if relay_ids? do
       case decode_relay_id(id) do
-        {:ok, {^type, primary_key}} ->
+        {:ok, %{type: ^type, id: primary_key}} ->
           decode_primary_key(resource, primary_key)
 
         _ ->
@@ -474,7 +474,7 @@ defmodule AshGraphql.Resource do
 
     type = String.to_existing_atom(type_string)
 
-    {:ok, {type, primary_key}}
+    {:ok, %{type: type, id: primary_key}}
   rescue
     _ ->
       {:error, Ash.Error.Invalid.InvalidPrimaryKey.exception(resource: nil, value: id)}


### PR DESCRIPTION
Slight API improvement over #106.

This makes it more ergonomic to partially match on the return value (and it also makes it more explicit by explicitly labeling the two parts).

Also add tests for relay id encoding/decoding.

### Contributor checklist

- [x] Features include unit/acceptance tests
