### PR TITLE
improvement: make mutation arguments non-null

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,7 @@ config :ash, :validate_api_resource_inclusion?, false
 config :ash, :validate_api_config_inclusion?, false
 
 config :ash_graphql, :default_managed_relationship_type_name_template, :action_name
+config :ash_graphql, :allow_non_null_mutation_arguments?, true
 
 if Mix.env() == :dev do
   config :git_ops,

--- a/documentation/tutorials/getting-started-with-graphql.md
+++ b/documentation/tutorials/getting-started-with-graphql.md
@@ -21,6 +21,7 @@ in `config/config.exs`
 
 ```elixir
 config :ash_graphql, :default_managed_relationship_type_name_template, :action_name
+config :ash_graphql, :allow_non_null_mutation_arguments?, true
 ```
 
 This won't be necessary after the next major release, where this new configuration will be the default.

--- a/test/create_test.exs
+++ b/test/create_test.exs
@@ -376,7 +376,7 @@ defmodule AshGraphql.CreateTest do
   test "a create with a managed relationship works with many_to_many and [on_lookup: :relate, on_match: :relate]" do
     resp =
       """
-      mutation CreatePostWithCommentsAndTags($input: CreatePostWithCommentsAndTagsInput) {
+      mutation CreatePostWithCommentsAndTags($input: CreatePostWithCommentsAndTagsInput!) {
         createPostWithCommentsAndTags(input: $input) {
           result{
             text

--- a/test/destroy_test.exs
+++ b/test/destroy_test.exs
@@ -14,7 +14,7 @@ defmodule AshGraphql.DestroyTest do
 
     resp =
       """
-      mutation DeletePost($id: ID) {
+      mutation DeletePost($id: ID!) {
         deletePost(id: $id) {
           result{
             text
@@ -42,7 +42,7 @@ defmodule AshGraphql.DestroyTest do
 
     resp =
       """
-      mutation ArchivePost($id: ID) {
+      mutation ArchivePost($id: ID!) {
         deletePost(id: $id) {
           result{
             text
@@ -96,7 +96,7 @@ defmodule AshGraphql.DestroyTest do
 
     resp =
       """
-      mutation DeleteWithError($id: ID) {
+      mutation DeleteWithError($id: ID!) {
         deletePostWithError(id: $id) {
           result{
             text
@@ -128,7 +128,7 @@ defmodule AshGraphql.DestroyTest do
   test "destroying a non-existent record returns a not found error" do
     resp =
       """
-      mutation DeletePost($id: ID) {
+      mutation DeletePost($id: ID!) {
         deletePost(id: $id) {
           result{
             text
@@ -162,7 +162,7 @@ defmodule AshGraphql.DestroyTest do
 
     resp =
       """
-      mutation DeletePost($id: ID) {
+      mutation DeletePost($id: ID!) {
         deletePostWithError(id: $id) {
           result{
             text

--- a/test/update_test.exs
+++ b/test/update_test.exs
@@ -19,7 +19,7 @@ defmodule AshGraphql.UpdateTest do
 
     resp =
       """
-      mutation UpdatePost($id: ID, $input: UpdatePostInput) {
+      mutation UpdatePost($id: ID!, $input: UpdatePostInput) {
         updatePost(id: $id, input: $input) {
           result{
             text
@@ -209,7 +209,7 @@ defmodule AshGraphql.UpdateTest do
 
     resp =
       """
-      mutation UpdatePostConfirm($input: UpdatePostConfirmInput, $id: ID) {
+      mutation UpdatePostConfirm($input: UpdatePostConfirmInput, $id: ID!) {
         updatePostConfirm(input: $input, id: $id) {
           result{
             text
@@ -253,7 +253,7 @@ defmodule AshGraphql.UpdateTest do
 
     resp =
       """
-      mutation UpdatePostConfirm($input: UpdatePostConfirmInput, $id: ID) {
+      mutation UpdatePostConfirm($input: UpdatePostConfirmInput, $id: ID!) {
         updatePostConfirm(input: $input, id: $id) {
           result{
             text


### PR DESCRIPTION
As discussed in #105 and #110, put this behind an opt-in configuration to avoid breaking existing code.
The ID in update mutations is always non-null if non-null mutation arguments are allowed, while input is non-null if it's allowed _and_ there is at least a non-null field in the input.

Document the newly added config variable in the getting started guide.

### Contributor checklist

- [x] Features include unit/acceptance tests
