### PR TITLE
Data layer functions

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -2106,6 +2106,7 @@ defmodule AshGraphql.Resource do
 
     fields =
       Ash.Filter.builtin_operators()
+      |> Enum.concat(Ash.DataLayer.functions(resource))
       |> Enum.filter(& &1.predicate?)
       |> restrict_for_lists(type)
       |> Enum.flat_map(fn operator ->

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -2224,7 +2224,11 @@ defmodule AshGraphql.Resource do
 
   defp do_get_expressable_types(operator_types, field_type, array_type?) do
     field_type_short_name =
-      Ash.Type.short_names() |> Enum.find(fn {_, type} -> type == field_type end) |> elem(0)
+      case Ash.Type.short_names()
+           |> Enum.find(fn {_, type} -> type == field_type end) do
+        nil -> nil
+        {short_name, _} -> short_name
+      end
 
     operator_types
     |> Enum.filter(fn
@@ -2243,7 +2247,7 @@ defmodule AshGraphql.Resource do
       [:any, type] when is_atom(type) ->
         true
 
-      [^field_type_short_name, type] when is_atom(type) ->
+      [^field_type_short_name, type] when is_atom(type) and not is_nil(field_type_short_name) ->
         true
 
       _ ->


### PR DESCRIPTION
Allow DataLayer Filters (like, ilike from postgres in filter) 

depends on 
* https://github.com/ash-project/ash_postgres/pull/205
* https://github.com/ash-project/ash/pull/874

Very naive first implementation. It works in my project already, but I feel I'm probably missing some edge cases.
Somehow, the filter is already only applied to String attributes, but I'm not completely sure why. 
