### PR TITLE
fix: make results nullable again if root level errors are enabled

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -610,9 +610,7 @@ defmodule AshGraphql.Resource do
             module: schema,
             name: to_string(mutation.name),
             description: Ash.Resource.Info.action(resource, mutation.action).description,
-            type: %Absinthe.Blueprint.TypeReference.NonNull{
-              of_type: String.to_atom("#{mutation.name}_result")
-            },
+            type: mutation_result_type(mutation.name, api),
             __reference__: ref(__ENV__)
           }
         end
@@ -656,9 +654,7 @@ defmodule AshGraphql.Resource do
           module: schema,
           name: to_string(mutation.name),
           description: Ash.Resource.Info.action(resource, mutation.action).description,
-          type: %Absinthe.Blueprint.TypeReference.NonNull{
-            of_type: String.to_atom("#{mutation.name}_result")
-          },
+          type: mutation_result_type(mutation.name, api),
           __reference__: ref(__ENV__)
         }
 
@@ -710,11 +706,16 @@ defmodule AshGraphql.Resource do
       module: schema,
       name: to_string(mutation.name),
       description: Ash.Resource.Info.action(resource, mutation.action).description,
-      type: %Absinthe.Blueprint.TypeReference.NonNull{
-        of_type: String.to_atom("#{mutation.name}_result")
-      },
+      type: mutation_result_type(mutation.name, api),
       __reference__: ref(__ENV__)
     }
+  end
+
+  defp mutation_result_type(mutation_name, api) do
+    type = String.to_atom("#{mutation_name}_result")
+    root_level_errors? = AshGraphql.Api.Info.root_level_errors?(api)
+
+    maybe_wrap_non_null(type, not root_level_errors?)
   end
 
   defp mutation_args(%{identity: false} = mutation, resource, schema) do

--- a/test/support/root_level_errors_api.ex
+++ b/test/support/root_level_errors_api.ex
@@ -1,0 +1,17 @@
+defmodule AshGraphql.Test.RootLevelErrorsApi do
+  @moduledoc false
+
+  use Ash.Api,
+    extensions: [
+      AshGraphql.Api
+    ],
+    otp_app: :ash_graphql
+
+  graphql do
+    root_level_errors? true
+  end
+
+  resources do
+    registry(AshGraphql.Test.Registry)
+  end
+end

--- a/test/support/root_level_errors_schema.ex
+++ b/test/support/root_level_errors_schema.ex
@@ -1,0 +1,30 @@
+defmodule AshGraphql.Test.RootLevelErrorsSchema do
+  @moduledoc false
+
+  use Absinthe.Schema
+
+  @apis [AshGraphql.Test.RootLevelErrorsApi]
+
+  use AshGraphql, apis: @apis
+
+  query do
+  end
+
+  mutation do
+  end
+
+  object :foo do
+    field(:foo, :string)
+    field(:bar, :string)
+  end
+
+  input_object :foo_input do
+    field(:foo, non_null(:string))
+    field(:bar, non_null(:string))
+  end
+
+  enum :status do
+    value(:open, description: "The post is open")
+    value(:closed, description: "The post is closed")
+  end
+end


### PR DESCRIPTION
Building upon #110, this restores the old behaviour of the result being nullable when root level errors are present.

While the result is guaranteed to not be nullable in standard conditions (since either result or errors are always present), when errors are moved to the root level it could become null, so declaring it non-nullable propagates the null up to the data field.

This actually causes compatibility problems with some client libraries (e.g. Relay) that expect the inner result to be null, _not_ data, if there's an error.

This also adds dedicated RootLevelErrors versions of the Api and the Schema since the configuration is accessed at compile time now, so put_env was not enough to test them correctly.

### Contributor checklist

- [x] Bug fixes include regression tests
