### PR TITLE
improvement: add `show_fields` option as explicit fields whitelist

### DIFF
--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -99,9 +99,17 @@ defmodule AshGraphql.Resource.Info do
     Extension.get_opt(resource, [:graphql], :hide_fields, [])
   end
 
+  @doc "Fields to show in the graphql api"
+  def show_fields(resource) do
+    Extension.get_opt(resource, [:graphql], :show_fields, nil)
+  end
+
   @doc "Wether or not a given field will be shown"
   def show_field?(resource, field) do
-    field not in hide_fields(resource)
+    hide_fields = hide_fields(resource)
+    show_fields = show_fields(resource) || [field]
+
+    field not in hide_fields and field in show_fields
   end
 
   @doc "Which relationships should be included in the generated type"

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -318,6 +318,11 @@ defmodule AshGraphql.Resource do
         type: {:list, :atom},
         doc: "A list of attributes to hide from the api"
       ],
+      show_fields: [
+        type: {:list, :atom},
+        doc:
+          "A list of attributes to show in the api. If not specified includes all (excluding `hide_fiels`)."
+      ],
       argument_names: [
         type: :keyword_list,
         doc:


### PR DESCRIPTION
There is `hide_fields` option. How about adding `show_fields` option that if present acts like an explicit list of allowed fields?

My use case is that I want to move graphql section out of resources into separate folder with `Spark.Dsl.Fragment`. But it means that looking just at that file you won't have context about present fields. With this you would have some idea.

Plus it is good from security perspective since you might add an attribute and forget to add it to `hide_fields`.