### PR TITLE
fix: don't deduplicate argument types by argument name

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3176,7 +3176,6 @@ defmodule AshGraphql.Resource do
           !Enum.empty?(Ash.Type.NewType.constraints(&1.type, &1.constraints)[:fields] || []) &&
           define_type?(&1.type, &1.constraints))
     )
-    |> Enum.uniq_by(& &1.name)
   end
 
   @spec define_type?(Ash.Type.t(), Ash.Type.constraints()) :: boolean()

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -73,4 +73,49 @@ defmodule AshGraphql.ResourceTest do
     assert create_post_with_custom_description_mutation["description"] ==
              "Another custom description"
   end
+
+  test "arguments with the same name can generate different types for different mutations" do
+    {:ok, %{data: with_foo}} =
+      """
+      query {
+        __type(name: "CreatePostBarWithFooInput") {
+          name
+          inputFields {
+            name
+            type {
+              name
+            }
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    {:ok, %{data: with_baz}} =
+      """
+      query {
+        __type(name: "CreatePostBarWithBazInput") {
+          name
+          inputFields {
+            name
+            type {
+              name
+            }
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    bar_with_foo =
+      with_foo["__type"]["inputFields"]
+      |> Enum.find(&(&1["name"] == "bar"))
+
+    bar_with_baz =
+      with_baz["__type"]["inputFields"]
+      |> Enum.find(&(&1["name"] == "bar"))
+
+    assert bar_with_foo["type"] == %{"name" => "BarWithFoo"}
+    assert bar_with_baz["type"] == %{"name" => "BarWithBaz"}
+  end
 end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -58,6 +58,44 @@ defmodule AfterActionRaiseResourceError do
   end
 end
 
+defmodule BarWithFoo do
+  @moduledoc false
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        foo: [
+          type: :string,
+          allow_nil?: false
+        ]
+      ]
+    ]
+
+  use AshGraphql.Type
+
+  @impl true
+  def graphql_input_type(_), do: :bar_with_foo
+end
+
+defmodule BarWithBaz do
+  @moduledoc false
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        baz: [
+          type: :integer,
+          allow_nil?: false
+        ]
+      ]
+    ]
+
+  use AshGraphql.Type
+
+  @impl true
+  def graphql_input_type(_), do: :bar_with_baz
+end
+
 defmodule RelatedPosts do
   @moduledoc false
   use Ash.Resource.ManualRelationship
@@ -160,6 +198,9 @@ defmodule AshGraphql.Test.Post do
       create :create_post, :create_confirm
       create :upsert_post, :upsert, upsert?: true
 
+      create :create_post_bar_with_foo, :create_bar_with_foo
+      create :create_post_bar_with_baz, :create_bar_with_baz
+
       create :create_post_with_comments, :with_comments
       create :create_post_with_comments_and_tags, :with_comments_and_tags
 
@@ -196,6 +237,14 @@ defmodule AshGraphql.Test.Post do
 
       change(SetMetadata)
       change(set_attribute(:author_id, arg(:author_id)))
+    end
+
+    create :create_bar_with_foo do
+      argument(:bar, BarWithFoo)
+    end
+
+    create :create_bar_with_baz do
+      argument(:bar, BarWithBaz)
     end
 
     create :create_with_error do


### PR DESCRIPTION
As mentioned in the upgrade guide, the point of dropping auto generation of types was to avoid conflicts when two arguments had the same name but different types. Now that we require explicit generation, we can actually support that usecase for, e.g., arguments with the same name but different types in create/update mutations.

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
