### PR TITLE
feat: relationship pagination

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -42,6 +42,7 @@ spark_locals_without_parens = [
   metadata_names: 1,
   metadata_types: 1,
   modify_resolution: 1,
+  paginate_relationship_with: 1,
   paginate_with: 1,
   primary_key_delimiter: 1,
   read_action: 1,

--- a/documentation/dsls/DSL:-AshGraphql.Resource.md
+++ b/documentation/dsls/DSL:-AshGraphql.Resource.md
@@ -56,6 +56,7 @@ end
 | [`derive_sort?`](#graphql-derive_sort?){: #graphql-derive_sort? } | `boolean` | `true` | Set to false to disable the automatic generation of a sort input for read actions. |
 | [`encode_primary_key?`](#graphql-encode_primary_key?){: #graphql-encode_primary_key? } | `boolean` | `true` | For resources with composite primary keys, or primary keys not called `:id`, this will cause the id to be encoded as a single `id` attribute, both in the representation of the resource and in get requests |
 | [`relationships`](#graphql-relationships){: #graphql-relationships } | `list(atom)` |  | A list of relationships to include on the created type. Defaults to all public relationships where the destination defines a graphql type. |
+| [`paginate_relationship_with`](#graphql-paginate_relationship_with){: #graphql-paginate_relationship_with } | `keyword` | `[]` | A keyword list indicating which kind of pagination should be used for each `has_many` and `many_to_many` relationships, e.g. `related_things: :keyset, other_related_things: :offset`. Valid pagination values are `nil`, `:offset`, `:keyset` and `:relay`. |
 | [`field_names`](#graphql-field_names){: #graphql-field_names } | `keyword` |  | A keyword list of name overrides for attributes. |
 | [`hide_fields`](#graphql-hide_fields){: #graphql-hide_fields } | `list(atom)` |  | A list of attributes to hide from the domain |
 | [`show_fields`](#graphql-show_fields){: #graphql-show_fields } | `list(atom)` |  | A list of attributes to show in the domain. If not specified includes all (excluding `hide_fiels`). |

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -149,6 +149,11 @@ defmodule AshGraphql.Resource.Info do
       resource |> Ash.Resource.Info.public_relationships() |> Enum.map(& &1.name)
   end
 
+  @doc "Pagination configuration for list relationships"
+  def paginate_relationship_with(resource) do
+    Extension.get_opt(resource, [:graphql], :paginate_relationship_with, [])
+  end
+
   @doc "Graphql argument name overrides for the resource"
   def argument_names(resource) do
     Extension.get_opt(resource, [:graphql], :argument_names, [])

--- a/lib/resource/verifiers/verify_paginate_relationship_with.ex
+++ b/lib/resource/verifiers/verify_paginate_relationship_with.ex
@@ -1,0 +1,55 @@
+defmodule AshGraphql.Resource.Verifiers.VerifyPaginateRelationshipWith do
+  # Validates the paginate_relationship_with option
+  @moduledoc false
+
+  use Spark.Dsl.Verifier
+
+  alias Spark.Dsl.Verifier
+
+  @valid_strategies [
+    nil,
+    :keyset,
+    :offset,
+    :relay
+  ]
+
+  def verify(dsl) do
+    many_relationship_names =
+      dsl
+      |> Verifier.get_entities([:relationships])
+      |> Enum.filter(&(&1.cardinality == :many))
+      |> Enum.map(& &1.name)
+
+    dsl
+    |> Verifier.get_option([:graphql], :paginate_relationship_with, [])
+    |> Enum.each(fn {relationship_name, strategy} ->
+      cond do
+        relationship_name not in many_relationship_names ->
+          module = Verifier.get_persisted(dsl, :module)
+
+          raise Spark.Error.DslError,
+            module: module,
+            path: [:graphql, :paginate_relationship_with],
+            message: """
+            #{relationship_name} is not a relationship with cardinality many.
+            """
+
+        strategy not in @valid_strategies ->
+          module = Verifier.get_persisted(dsl, :module)
+          choices = Enum.map_join(@valid_strategies, ", ", &inspect/1)
+
+          raise Spark.Error.DslError,
+            module: module,
+            path: [:graphql, :paginate_relationship_with],
+            message: """
+            #{inspect(strategy)} is not a valid pagination strategy for relationships.
+
+            Available strategies: #{choices}
+            """
+
+        true ->
+          :ok
+      end
+    end)
+  end
+end

--- a/test/paginate_test.exs
+++ b/test/paginate_test.exs
@@ -67,6 +67,44 @@ defmodule AshGraphql.PaginateTest do
       assert is_binary(start_keyset)
       assert is_binary(end_keyset)
     end
+
+    test "works if action has both offset and keyset pagination" do
+      doc = """
+      query OtherKeysetPaginatedPosts {
+        otherKeysetPaginatedPosts(sort: [{field: TEXT, order: ASC_NULLS_LAST}]) {
+          count
+          startKeyset
+          endKeyset
+          results{
+            text
+            keyset
+          }
+        }
+      }
+      """
+
+      assert {:ok,
+              %{
+                data: %{
+                  "otherKeysetPaginatedPosts" => %{
+                    "startKeyset" => start_keyset,
+                    "endKeyset" => end_keyset,
+                    "count" => 5,
+                    "results" => [
+                      %{"text" => "a", "keyset" => keyset},
+                      %{"text" => "b"},
+                      %{"text" => "c"},
+                      %{"text" => "d"},
+                      %{"text" => "e"}
+                    ]
+                  }
+                }
+              }} = Absinthe.run(doc, AshGraphql.Test.Schema)
+
+      assert is_binary(keyset)
+      assert is_binary(start_keyset)
+      assert is_binary(end_keyset)
+    end
   end
 
   describe "offset pagination" do

--- a/test/relationship_pagination_test.exs
+++ b/test/relationship_pagination_test.exs
@@ -1,0 +1,341 @@
+defmodule AshGraphql.RelationshipPaginationTest do
+  use ExUnit.Case, async: false
+
+  require Ash.Query
+
+  setup do
+    on_exit(fn ->
+      AshGraphql.TestHelpers.stop_ets()
+    end)
+  end
+
+  test "works with :relay strategy" do
+    movie =
+      AshGraphql.Test.Movie
+      |> Ash.Changeset.for_create(:create, title: "Foo")
+      |> Ash.create!()
+
+    for i <- 1..5 do
+      AshGraphql.Test.Actor
+      |> Ash.Changeset.for_create(:create, name: "Actor #{i}")
+      |> Ash.Changeset.manage_relationship(:movies, movie, type: :append)
+      |> Ash.create!()
+    end
+
+    document =
+      """
+      query Movies($first: Int, $after: String) {
+        getMovies {
+          actors(first: $first, after: $after, sort: [{field: NAME}]) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+              startCursor
+              endCursor
+            }
+            count
+            edges {
+              cursor
+              node {
+                name
+              }
+            }
+          }
+        }
+      }
+      """
+
+    resp = Absinthe.run(document, AshGraphql.Test.Schema, variables: %{"first" => 1})
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "actors" => %{
+                     "count" => 5,
+                     "edges" => [%{"cursor" => cursor, "node" => %{"name" => "Actor 1"}}],
+                     "pageInfo" => %{
+                       "hasPreviousPage" => false,
+                       "hasNextPage" => true
+                     }
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    resp =
+      Absinthe.run(document, AshGraphql.Test.Schema,
+        variables: %{"first" => 4, "after" => cursor}
+      )
+
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "actors" => %{
+                     "edges" => edges,
+                     "pageInfo" => %{
+                       "hasPreviousPage" => true,
+                       "hasNextPage" => false
+                     }
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    assert length(edges) == 4
+    assert [%{"node" => %{"name" => "Actor 2"}} | _] = edges
+  end
+
+  test "works with :offset strategy" do
+    movie =
+      AshGraphql.Test.Movie
+      |> Ash.Changeset.for_create(:create, title: "Foo")
+      |> Ash.create!()
+
+    for i <- 1..5 do
+      AshGraphql.Test.Review
+      |> Ash.Changeset.for_create(:create, text: "Review #{i}")
+      |> Ash.Changeset.manage_relationship(:movie, movie, type: :append)
+      |> Ash.create!()
+    end
+
+    document =
+      """
+      query Movies($limit: Int, $offset: Int) {
+        getMovies {
+          reviews(limit: $limit, offset: $offset, sort: [{field: TEXT}]) {
+            results {
+              text
+            }
+            count
+            hasNextPage
+          }
+        }
+      }
+      """
+
+    resp = Absinthe.run(document, AshGraphql.Test.Schema, variables: %{"limit" => 1})
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "reviews" => %{
+                     "count" => 5,
+                     "results" => [%{"text" => "Review 1"}],
+                     "hasNextPage" => true
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    resp =
+      Absinthe.run(document, AshGraphql.Test.Schema, variables: %{"limit" => 4, "offset" => 1})
+
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "reviews" => %{
+                     "results" => results,
+                     "hasNextPage" => false
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    assert length(results) == 4
+    assert [%{"text" => "Review 2"} | _] = results
+  end
+
+  test "works with :keyset strategy" do
+    movie =
+      AshGraphql.Test.Movie
+      |> Ash.Changeset.for_create(:create, title: "Foo")
+      |> Ash.create!()
+
+    for i <- 1..5 do
+      AshGraphql.Test.Award
+      |> Ash.Changeset.for_create(:create, name: "Award #{i}")
+      |> Ash.Changeset.manage_relationship(:movie, movie, type: :append)
+      |> Ash.create!()
+    end
+
+    document =
+      """
+      query Movies($first: Int, $after: String) {
+        getMovies {
+          awards(first: $first, after: $after, sort: [{field: NAME}]) {
+            results {
+              name
+            }
+            count
+            endKeyset
+          }
+        }
+      }
+      """
+
+    resp = Absinthe.run(document, AshGraphql.Test.Schema, variables: %{"first" => 1})
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "awards" => %{
+                     "count" => 5,
+                     "results" => [%{"name" => "Award 1"}],
+                     "endKeyset" => cursor
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    resp =
+      Absinthe.run(document, AshGraphql.Test.Schema,
+        variables: %{"first" => 4, "after" => cursor}
+      )
+
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{data: %{"getMovies" => [%{"awards" => %{"results" => results}}]}} = result
+
+    assert length(results) == 4
+    assert [%{"name" => "Award 2"} | _] = results
+  end
+
+  test "works when nested" do
+    movie =
+      AshGraphql.Test.Movie
+      |> Ash.Changeset.for_create(:create, title: "Movie")
+      |> Ash.create!()
+
+    agents =
+      for i <- 1..4 do
+        AshGraphql.Test.Agent
+        |> Ash.Changeset.for_create(:create, name: "Agent #{i}")
+        |> Ash.create!()
+      end
+
+    for i <- 1..5 do
+      AshGraphql.Test.Actor
+      |> Ash.Changeset.for_create(:create, name: "Actor #{i}")
+      |> Ash.Changeset.manage_relationship(:movies, movie, type: :append)
+      |> Ash.Changeset.manage_relationship(:agents, agents, type: :append)
+      |> Ash.create!()
+    end
+
+    document =
+      """
+      query Movies($first: Int, $after: String) {
+        getMovies(sort: [{field: TITLE}]) {
+          actors(first: 1, sort: [{field: NAME}]) {
+            count
+            edges {
+              cursor
+              node {
+                name
+                agents(first: $first, after: $after, sort: [{field: NAME}]) {
+                  count
+                  edges {
+                    cursor
+                    node {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+
+    resp = Absinthe.run(document, AshGraphql.Test.Schema, variables: %{"first" => 1})
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "actors" => %{
+                     "count" => 5,
+                     "edges" => [
+                       %{
+                         "node" => %{
+                           "name" => "Actor 1",
+                           "agents" => %{
+                             "count" => 4,
+                             "edges" => [
+                               %{
+                                 "cursor" => cursor,
+                                 "node" => %{
+                                   "name" => "Agent 1"
+                                 }
+                               }
+                             ]
+                           }
+                         }
+                       }
+                     ]
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    resp =
+      Absinthe.run(document, AshGraphql.Test.Schema,
+        variables: %{"first" => 3, "after" => cursor}
+      )
+
+    assert {:ok, result} = resp
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "getMovies" => [
+                 %{
+                   "actors" => %{
+                     "count" => 5,
+                     "edges" => [
+                       %{
+                         "node" => %{
+                           "name" => "Actor 1",
+                           "agents" => %{
+                             "count" => 4,
+                             "edges" => edges
+                           }
+                         }
+                       }
+                     ]
+                   }
+                 }
+               ]
+             }
+           } = result
+
+    assert length(edges) == 3
+    assert [%{"node" => %{"name" => "Agent 2"}} | _] = edges
+  end
+end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -15,12 +15,18 @@ defmodule AshGraphql.Test.Domain do
   end
 
   resources do
+    resource(AshGraphql.Test.Actor)
+    resource(AshGraphql.Test.ActorAgent)
+    resource(AshGraphql.Test.Agent)
+    resource(AshGraphql.Test.Award)
     resource(AshGraphql.Test.Comment)
     resource(AshGraphql.Test.CompositePrimaryKey)
     resource(AshGraphql.Test.CompositePrimaryKeyNotEncoded)
     resource(AshGraphql.Test.DoubleRelRecursive)
     resource(AshGraphql.Test.DoubleRelToRecursiveParentOfEmbed)
     resource(AshGraphql.Test.MapTypes)
+    resource(AshGraphql.Test.Movie)
+    resource(AshGraphql.Test.MovieActor)
     resource(AshGraphql.Test.MultitenantPostTag)
     resource(AshGraphql.Test.MultitenantTag)
     resource(AshGraphql.Test.NoGraphql)
@@ -30,6 +36,7 @@ defmodule AshGraphql.Test.Domain do
     resource(AshGraphql.Test.PostTag)
     resource(AshGraphql.Test.RelayPostTag)
     resource(AshGraphql.Test.RelayTag)
+    resource(AshGraphql.Test.Review)
     resource(AshGraphql.Test.SponsoredComment)
     resource(AshGraphql.Test.Tag)
     resource(AshGraphql.Test.User)

--- a/test/support/resources/actor.ex
+++ b/test/support/resources/actor.ex
@@ -1,0 +1,37 @@
+defmodule AshGraphql.Test.Actor do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:actor)
+
+    paginate_relationship_with(agents: :relay)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:name, :string, public?: true)
+  end
+
+  relationships do
+    many_to_many(:movies, AshGraphql.Test.Movie,
+      through: AshGraphql.Test.MovieActor,
+      public?: true
+    )
+
+    many_to_many(:agents, AshGraphql.Test.Agent,
+      through: AshGraphql.Test.ActorAgent,
+      public?: true
+    )
+  end
+end

--- a/test/support/resources/actor_agent.ex
+++ b/test/support/resources/actor_agent.ex
@@ -1,0 +1,23 @@
+defmodule AshGraphql.Test.ActorAgent do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  actions do
+    defaults([:create, :update, :destroy, :read])
+  end
+
+  relationships do
+    belongs_to :actor, AshGraphql.Test.Actor do
+      primary_key?(true)
+      allow_nil?(false)
+    end
+
+    belongs_to :agent, AshGraphql.Test.Agent do
+      primary_key?(true)
+      allow_nil?(false)
+    end
+  end
+end

--- a/test/support/resources/agent.ex
+++ b/test/support/resources/agent.ex
@@ -1,0 +1,32 @@
+defmodule AshGraphql.Test.Agent do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:agent)
+
+    paginate_relationship_with(actors: :relay)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:name, :string, public?: true)
+  end
+
+  relationships do
+    many_to_many(:actors, AshGraphql.Test.Actor,
+      through: AshGraphql.Test.ActorAgent,
+      public?: true
+    )
+  end
+end

--- a/test/support/resources/award.ex
+++ b/test/support/resources/award.ex
@@ -1,0 +1,27 @@
+defmodule AshGraphql.Test.Award do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:award)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:name, :string, public?: true)
+  end
+
+  relationships do
+    belongs_to(:movie, AshGraphql.Test.Movie, public?: true)
+  end
+end

--- a/test/support/resources/movie.ex
+++ b/test/support/resources/movie.ex
@@ -1,0 +1,40 @@
+defmodule AshGraphql.Test.Movie do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:movie)
+
+    paginate_relationship_with(actors: :relay, reviews: :offset, awards: :keyset)
+
+    queries do
+      get :get_movie, :read
+      list :get_movies, :read, paginate_with: nil
+    end
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:title, :string, public?: true)
+  end
+
+  relationships do
+    many_to_many(:actors, AshGraphql.Test.Actor,
+      through: AshGraphql.Test.MovieActor,
+      public?: true
+    )
+
+    has_many(:reviews, AshGraphql.Test.Review, public?: true)
+    has_many(:awards, AshGraphql.Test.Award, public?: true)
+  end
+end

--- a/test/support/resources/movie_actor.ex
+++ b/test/support/resources/movie_actor.ex
@@ -1,0 +1,23 @@
+defmodule AshGraphql.Test.MovieActor do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets
+
+  actions do
+    defaults([:create, :update, :destroy, :read])
+  end
+
+  relationships do
+    belongs_to :movie, AshGraphql.Test.Movie do
+      primary_key?(true)
+      allow_nil?(false)
+    end
+
+    belongs_to :actor, AshGraphql.Test.Actor do
+      primary_key?(true)
+      allow_nil?(false)
+    end
+  end
+end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -173,6 +173,7 @@ defmodule AshGraphql.Test.Post do
       list :post_library, :library
       list :paginated_posts, :paginated
       list :keyset_paginated_posts, :keyset_paginated
+      list :other_keyset_paginated_posts, :keyset_and_offset_paginated, paginate_with: :keyset
       list :paginated_posts_without_limit, :paginated_without_limit
       list :paginated_posts_limit_not_required, :paginated_limit_not_required
       action(:post_count, :count)
@@ -322,6 +323,16 @@ defmodule AshGraphql.Test.Post do
       pagination(
         required?: true,
         keyset?: true,
+        countable: true,
+        default_limit: 20
+      )
+    end
+
+    read :keyset_and_offset_paginated do
+      pagination(
+        required?: true,
+        keyset?: true,
+        offset?: true,
         countable: true,
         default_limit: 20
       )

--- a/test/support/resources/review.ex
+++ b/test/support/resources/review.ex
@@ -1,0 +1,27 @@
+defmodule AshGraphql.Test.Review do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:review)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:text, :string, public?: true)
+  end
+
+  relationships do
+    belongs_to(:movie, AshGraphql.Test.Movie, public?: true)
+  end
+end


### PR DESCRIPTION
Resources can now define how their relationships are paginated. This is a property of the Graphql type of the resource and it allows arbitrarily nested paginated relationships.

The PR also contains a fix to the existing pagination, which was not working correctly when a keyset strategy was used with an action that also supported offset pagination.

Close #131 

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
