### PR TITLE
chore: add tests on paginated relationships

### DIFF
--- a/test/support/resources/movie.ex
+++ b/test/support/resources/movie.ex
@@ -15,11 +15,26 @@ defmodule AshGraphql.Test.Movie do
       get :get_movie, :read
       list :get_movies, :read, paginate_with: nil
     end
+
+    mutations do
+      create :create_movie, :create_with_actors
+      update :update_movie, :update
+      destroy :destroy_movie, :destroy
+    end
   end
 
   actions do
     default_accept(:*)
     defaults([:create, :read, :update, :destroy])
+
+    create :create_with_actors do
+      argument :actor_ids, {:array, :uuid} do
+        allow_nil? false
+        constraints(min_length: 1)
+      end
+
+      change(manage_relationship(:actor_ids, :actors, type: :append))
+    end
   end
 
   attributes do


### PR DESCRIPTION
Following on ash-project/ash#1234, this PR adds tests to verify that relationships can be queried on the results of GraphQL queries and mutations.

Querying paginated relationships on the result of deletions doesn't correctly work yet.
Indeed, Ash currently queries relationships using a lateral join but after the resource deletion has happened, so it looks like nothing is related.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
