### PR TITLE
fix: use checked constraints

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -4160,7 +4160,7 @@ defmodule AshGraphql.Resource do
         else
           if Spark.implements_behaviour?(type, Ash.Type.Enum) do
             if function_exported?(type, :graphql_type, 1) do
-              type.graphql_type(attribute.constraints)
+              type.graphql_type(constraints)
             else
               :string
             end


### PR DESCRIPTION
I had this fail because I created a new Type (subtype of map with a field that was an enum)

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
