### PR TITLE
bugfix: Fix check for checking if a field is filterable or not

### DIFF
--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -190,9 +190,9 @@ defmodule AshGraphql.Resource.Info do
   end
 
   @doc "May the specified field be filtered on?"
-  def filterable_field?(resource, field) do
+  def filterable_field?(resource, field_name) do
     filterable_fields = AshGraphql.Resource.Info.filterable_fields(resource)
 
-    is_nil(filterable_fields) or field.name in filterable_fields
+    is_nil(filterable_fields) or field_name in filterable_fields
   end
 end

--- a/test/support/resources/tag.ex
+++ b/test/support/resources/tag.ex
@@ -9,6 +9,8 @@ defmodule AshGraphql.Test.Tag do
   graphql do
     type(:tag)
 
+    filterable_fields [:name]
+
     queries do
       get :get_tag, :read
       list :get_tags, :read


### PR DESCRIPTION
The calling function passes in `field.name`, the `filterable_field?` function should not attempt to access the name again

This fixes a compilation error when using the `filterable_fields` config option anywhere in your app

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

(well technically I didn't add any test, but adding the `filterable_fields` option to a test resource causes the app to not compile anymore without the code change)