### PR TITLE
fix: error handling list of atoms

### DIFF
--- a/lib/default_error_handler.ex
+++ b/lib/default_error_handler.ex
@@ -24,10 +24,13 @@ defmodule AshGraphql.DefaultErrorHandler do
 
     Enum.reduce(vars, string, fn {key, value}, acc ->
       if String.contains?(acc, "%{#{key}}") do
-        String.replace(acc, "%{#{key}}", to_string(value))
+        String.replace(acc, "%{#{key}}", stringified_value(value))
       else
         acc
       end
     end)
   end
+
+  def stringified_value(value) when is_list(value), do: "[#{value |> Enum.map(&to_string(&1)) |> Enum.join(", ")}]"
+  def stringified_value(value), do: to_string(value)
 end

--- a/lib/default_error_handler.ex
+++ b/lib/default_error_handler.ex
@@ -31,6 +31,6 @@ defmodule AshGraphql.DefaultErrorHandler do
     end)
   end
 
-  def stringified_value(value) when is_list(value), do: "[#{value |> Enum.map(&to_string(&1)) |> Enum.join(", ")}]"
+  def stringified_value(value) when is_list(value), do: "[#{value |> Enum.map(&stringified_value(&1)) |> Enum.join(", ")}]"
   def stringified_value(value), do: to_string(value)
 end


### PR DESCRIPTION
Current implementation doesn't support basic case of list of atoms as errors.
```
** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must either be empty or only
contain the following elements:

  * strings
  * integers representing Unicode code points
  * a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

[:option1, :option2, :option3]
```


### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
