### PR TITLE
chore: Set up GraphQL schema file in the web module namespace

### DIFF
--- a/lib/mix/tasks/ash_graphql.install.ex
+++ b/lib/mix/tasks/ash_graphql.install.ex
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.AshGraphql.Install do
       |> Spark.Igniter.prepend_to_section_order(:"Ash.Resource", [:graphql])
       |> Spark.Igniter.prepend_to_section_order(:"Ash.Domain", [:graphql])
 
-    schema_name = Igniter.Code.Module.module_name("GraphqlSchema")
+    schema_name = Igniter.Libs.Phoenix.web_module_name("GraphqlSchema")
 
     {igniter, candidate_ash_graphql_schemas} =
       AshGraphql.Igniter.ash_graphql_schemas(igniter)


### PR DESCRIPTION
This keeps consistency with AshJsonApi, which generates its router in the web module namespace as well

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
