### PR TITLE
docs: Use correct arity for graphql_type

### DIFF
--- a/documentation/topics/use-enums-with-graphql.md
+++ b/documentation/topics/use-enums-with-graphql.md
@@ -11,7 +11,7 @@ defmodule AshPostgres.Test.Types.Status do
   @moduledoc false
   use Ash.Type.Enum, values: [:open, :closed]
 
-  def graphql_type, do: :ticket_status
+  def graphql_type(_), do: :ticket_status
 
   # Optionally, remap the names used in GraphQL, for instance if you have a value like `:"10"`
   # that value is not compatible with GraphQL

--- a/documentation/topics/use-maps-with-graphql.md
+++ b/documentation/topics/use-maps-with-graphql.md
@@ -18,7 +18,7 @@ defmodule MyApp.Types.Metadata do
     ]
   ]
 
-  def graphql_type, do: :metadata
+  def graphql_type(_), do: :metadata
 end
 
 ```


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Small fix in the documentation to use `graphql_type/1` to have correct signature.