### PR TITLE
improvement: Support generic actions without a return type.

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -55,6 +55,9 @@ defmodule AshGraphql.Graphql.Resolver do
             |> Ash.ActionInput.for_action(action.name, arguments)
             |> Ash.run_action(opts)
             |> case do
+              :ok ->
+                {:ok, true}
+
               {:ok, result} ->
                 load_opts =
                   [

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -1643,12 +1643,8 @@ defmodule AshGraphql.Resource do
   end
 
   defp generic_action_type(action, resource) do
-    if !action.returns do
-      raise "Cannot use #{inspect(resource)}.#{action.name} with AshGraphql, because it does not have a return type."
-    end
-
     fake_attribute = %{
-      type: action.returns,
+      type: action.returns || Ash.Type.Boolean,
       constraints: action.constraints,
       allow_nil?: Map.get(action, :allow_nil?, false),
       name: action.name


### PR DESCRIPTION
Infer that their return type is `:boolean` and they always return `true`. We considered returning `null` but that's also returned when the query/mutation fails and might convey the wrong information.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
