### PR TITLE
Move the playground route  before the endpoint route

### DIFF
--- a/documentation/tutorials/getting-started-with-graphql.md
+++ b/documentation/tutorials/getting-started-with-graphql.md
@@ -75,14 +75,14 @@ end
 scope "/gql" do
   pipe_through [:graphql]
 
-  forward "/",
-    Absinthe.Plug,
-    schema: Module.concat(["Helpdesk.GraphqlSchema"])
-
   forward "/playground",
           Absinthe.Plug.GraphiQL,
           schema: Module.concat(["Helpdesk.GraphqlSchema"]),
           interface: :playground
+
+  forward "/",
+    Absinthe.Plug,
+    schema: Module.concat(["Helpdesk.GraphqlSchema"])
 end
 ```
 


### PR DESCRIPTION
### Contributor checklist

-  Correct an error in the documentation: The playground  was before the enddpoint rout, causing "No Query document supplied" 
- Moved the playground route  before the endpoint route
