### PR TITLE
fix: load relationships and calculations in fragments

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -670,7 +670,8 @@ defmodule AshGraphql do
       resource,
       resolution,
       resolution.path,
-      resolution.context
+      resolution.context,
+      nil
     )
   end
 

--- a/lib/subscriptions.ex
+++ b/lib/subscriptions.ex
@@ -35,7 +35,8 @@ defmodule AshGraphql.Subscription do
       query.resource,
       resolution,
       resolution.path,
-      context
+      context,
+      type_override
     )
   end
 end

--- a/test/support/relay_ids/domain.ex
+++ b/test/support/relay_ids/domain.ex
@@ -8,6 +8,7 @@ defmodule AshGraphql.Test.RelayIds.Domain do
     otp_app: :ash_graphql
 
   resources do
+    resource(AshGraphql.Test.RelayIds.Comment)
     resource(AshGraphql.Test.RelayIds.Post)
     resource(AshGraphql.Test.RelayIds.ResourceWithNoPrimaryKeyGet)
     resource(AshGraphql.Test.RelayIds.User)

--- a/test/support/relay_ids/resources/comment.ex
+++ b/test/support/relay_ids/resources/comment.ex
@@ -1,0 +1,65 @@
+defmodule AshGraphql.Test.RelayIds.Comment do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.RelayIds.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type :comment
+
+    queries do
+      list :list_comments, :read
+    end
+
+    mutations do
+      create :create_comment, :create
+    end
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :update, :destroy])
+
+    read :read do
+      primary?(true)
+    end
+
+    read :paginated do
+      pagination(required?: true, offset?: true, countable: true)
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+    attribute(:text, :string, public?: true)
+
+    attribute :type, :atom do
+      public?(true)
+      writable?(false)
+      default(:comment)
+      constraints(one_of: [:comment, :reply])
+    end
+
+    create_timestamp(:created_at)
+  end
+
+  calculations do
+    calculate(
+      :timestamp,
+      :utc_datetime_usec,
+      expr(created_at),
+      public?: true
+    )
+  end
+
+  relationships do
+    belongs_to(:post, AshGraphql.Test.RelayIds.Post, public?: true)
+
+    belongs_to :author, AshGraphql.Test.RelayIds.User do
+      public?(true)
+      attribute_writable?(true)
+    end
+  end
+end

--- a/test/support/relay_ids/resources/post.ex
+++ b/test/support/relay_ids/resources/post.ex
@@ -52,5 +52,7 @@ defmodule AshGraphql.Test.RelayIds.Post do
       public?(true)
       attribute_writable?(true)
     end
+
+    has_many(:comments, AshGraphql.Test.RelayIds.Comment, public?: true)
   end
 end

--- a/test/support/relay_ids/resources/user.ex
+++ b/test/support/relay_ids/resources/user.ex
@@ -42,4 +42,8 @@ defmodule AshGraphql.Test.RelayIds.User do
       public?: true
     )
   end
+
+  calculations do
+    calculate(:name_twice, :string, expr(name <> " " <> name), public?: true)
+  end
 end


### PR DESCRIPTION
Similar to what was done in 2886e0c8c1aea3c943d for selections, we have to do the same thing for loads to make them work with interface fragments (including the Relay node interface).

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
