### PR TITLE
feat: error handling in resources

### DIFF
--- a/documentation/dsls/DSL-AshGraphql.Domain.md
+++ b/documentation/dsls/DSL-AshGraphql.Domain.md
@@ -247,6 +247,7 @@ action :check_status, :check_status
 | [`description`](#graphql-queries-action-description){: #graphql-queries-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
 | [`hide_inputs`](#graphql-queries-action-hide_inputs){: #graphql-queries-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-queries-action-error_location){: #graphql-queries-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
+| [`modify_resolution`](#graphql-queries-action-modify_resolution){: #graphql-queries-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
 | [`relay_id_translations`](#graphql-queries-action-relay_id_translations){: #graphql-queries-action-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 
 
@@ -440,6 +441,7 @@ action :check_status, :check_status
 | [`description`](#graphql-mutations-action-description){: #graphql-mutations-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
 | [`hide_inputs`](#graphql-mutations-action-hide_inputs){: #graphql-mutations-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-mutations-action-error_location){: #graphql-mutations-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
+| [`modify_resolution`](#graphql-mutations-action-modify_resolution){: #graphql-mutations-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
 | [`relay_id_translations`](#graphql-mutations-action-relay_id_translations){: #graphql-mutations-action-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 
 

--- a/documentation/dsls/DSL-AshGraphql.Resource.md
+++ b/documentation/dsls/DSL-AshGraphql.Resource.md
@@ -72,6 +72,7 @@ end
 | [`generate_object?`](#graphql-generate_object?){: #graphql-generate_object? } | `boolean` | `true` | Whether or not to create the GraphQL object, this allows you to manually create the GraphQL object. |
 | [`filterable_fields`](#graphql-filterable_fields){: #graphql-filterable_fields } | `list(atom)` |  | A list of fields that are allowed to be filtered on. Defaults to all filterable fields for which a GraphQL type can be created. |
 | [`nullable_fields`](#graphql-nullable_fields){: #graphql-nullable_fields } | `atom \| list(atom)` |  | Mark fields as nullable even if they are required. This is useful when using field policies. See the authorization guide for more. |
+| [`error_handler`](#graphql-error_handler){: #graphql-error_handler } | `mfa` | `{AshGraphql.DefaultErrorHandler, :handle_error, []}` | Set an MFA to intercept/handle any errors that are generated. |
 
 
 ## graphql.queries
@@ -270,6 +271,7 @@ action :check_status, :check_status
 | [`description`](#graphql-queries-action-description){: #graphql-queries-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
 | [`hide_inputs`](#graphql-queries-action-hide_inputs){: #graphql-queries-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-queries-action-error_location){: #graphql-queries-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
+| [`modify_resolution`](#graphql-queries-action-modify_resolution){: #graphql-queries-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
 | [`relay_id_translations`](#graphql-queries-action-relay_id_translations){: #graphql-queries-action-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 
 
@@ -459,6 +461,7 @@ action :check_status, :check_status
 | [`description`](#graphql-mutations-action-description){: #graphql-mutations-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
 | [`hide_inputs`](#graphql-mutations-action-hide_inputs){: #graphql-mutations-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-mutations-action-error_location){: #graphql-mutations-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
+| [`modify_resolution`](#graphql-mutations-action-modify_resolution){: #graphql-mutations-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
 | [`relay_id_translations`](#graphql-mutations-action-relay_id_translations){: #graphql-mutations-action-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 
 

--- a/documentation/topics/handle-errors.md
+++ b/documentation/topics/handle-errors.md
@@ -81,6 +81,31 @@ defmodule AshGraphql.DefaultErrorHandler do
 end
 ```
 
+### Error handler in resources
+Error handlers can also be specified in a resource. For examples:
+
+```elixir
+defmodule MyApp.Resource do
+  use Ash.Resource,
+    domain: [MyApp.Domain],
+    extensions: [AshGraphql]
+    
+  graphql do
+    type :ticket
+    error_handler {MyApp.Resource.GraphqlErrorHandler, :handle_error, []}
+  end
+  
+  # ...
+end
+```
+
+If both an error handler for the resource and one for the domain are defined,
+they both take action: first the resource handler and then the domain handler.
+
+If an action on a resource calls other actions (e.g. with a
+`manage_relationships`) the errors are handled by the primary resource that
+called the action.
+
 ## Custom Errors
 
 If you created your own Errors as described in the [Ash Docs](https://hexdocs.pm/ash/error-handling.html#using-a-custom-exception) you also need to implement

--- a/lib/graphql/errors.ex
+++ b/lib/graphql/errors.ex
@@ -7,19 +7,28 @@ defmodule AshGraphql.Errors do
   @doc """
   Transform an error or list of errors into the response for graphql.
   """
-  def to_errors(errors, context, domain) do
+  def to_errors(errors, context, domain, resource) do
     errors
     |> AshGraphql.Graphql.Resolver.unwrap_errors()
     |> Enum.map(fn error ->
       if AshGraphql.Error.impl_for(error) do
         error = AshGraphql.Error.to_error(error)
 
+        resource_handled_error =
+          case AshGraphql.Resource.Info.error_handler(resource) do
+            nil ->
+              error
+
+            {m, f, a} ->
+              apply(m, f, [error, context | a])
+          end
+
         case AshGraphql.Domain.Info.error_handler(domain) do
           nil ->
-            error
+            resource_handled_error
 
           {m, f, a} ->
-            apply(m, f, [error, context | a])
+            apply(m, f, [resource_handled_error, context | a])
         end
       else
         uuid = Ash.UUID.generate()

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -125,7 +125,7 @@ defmodule AshGraphql.Graphql.Resolver do
                   {:ok, %{result: result, errors: []}}
 
                 {:error, errors} ->
-                  {:ok, %{result: nil, errors: to_errors(errors, context, domain)}}
+                  {:ok, %{result: nil, errors: to_errors(errors, context, domain, resource)}}
               end
             else
               result
@@ -139,7 +139,7 @@ defmodule AshGraphql.Graphql.Resolver do
               domain
             )
           )
-          |> add_root_errors(domain, result)
+          |> add_root_errors(domain, resource, result)
           |> modify_resolution(modify, modify_args)
         end
 
@@ -276,8 +276,10 @@ defmodule AshGraphql.Graphql.Resolver do
                 )
 
               resolution
-              |> Absinthe.Resolution.put_result({:error, to_errors([error], context, domain)})
-              |> add_root_errors(domain, result)
+              |> Absinthe.Resolution.put_result(
+                {:error, to_errors([error], context, domain, resource)}
+              )
+              |> add_root_errors(domain, resource, result)
 
             {result, _} ->
               resolution
@@ -292,7 +294,7 @@ defmodule AshGraphql.Graphql.Resolver do
                   domain
                 )
               )
-              |> add_root_errors(domain, result)
+              |> add_root_errors(domain, resource, result)
               |> modify_resolution(modify, modify_args)
           end
         end
@@ -390,7 +392,7 @@ defmodule AshGraphql.Graphql.Resolver do
 
         resolution
         |> Absinthe.Resolution.put_result(to_resolution(result, context, domain))
-        |> add_root_errors(domain, result)
+        |> add_root_errors(domain, resource, result)
         |> modify_resolution(modify, [query, args])
       end
     else
@@ -516,7 +518,7 @@ defmodule AshGraphql.Graphql.Resolver do
 
           resolution
           |> Absinthe.Resolution.put_result(to_resolution(result, context, domain))
-          |> add_root_errors(domain, modify_args)
+          |> add_root_errors(domain, resource, modify_args)
           |> modify_resolution(modify, modify_args)
         end
 
@@ -679,7 +681,8 @@ defmodule AshGraphql.Graphql.Resolver do
             [] ->
               Absinthe.Resolution.put_result(
                 resolution,
-                {:error, to_errors([Ash.Error.Query.NotFound.exception()], context, domain)}
+                {:error,
+                 to_errors([Ash.Error.Query.NotFound.exception()], context, domain, resource)}
               )
 
             [first | rest] ->
@@ -785,7 +788,8 @@ defmodule AshGraphql.Graphql.Resolver do
                 {:ok, nil} ->
                   resolution
                   |> Absinthe.Resolution.put_result(
-                    {:error, to_errors([Ash.Error.Query.NotFound.exception()], context, domain)}
+                    {:error,
+                     to_errors([Ash.Error.Query.NotFound.exception()], context, domain, resource)}
                   )
 
                 {:ok, result} ->
@@ -801,7 +805,9 @@ defmodule AshGraphql.Graphql.Resolver do
 
                 {:error, error} ->
                   resolution
-                  |> Absinthe.Resolution.put_result({:error, to_errors([error], context, domain)})
+                  |> Absinthe.Resolution.put_result(
+                    {:error, to_errors([error], context, domain, resource)}
+                  )
               end
 
             notification.action_type in [:destroy] ->
@@ -1470,13 +1476,14 @@ defmodule AshGraphql.Graphql.Resolver do
                  [changeset, {:ok, value}]}
 
               {:error, %{changeset: changeset} = error} ->
-                {{:ok, %{result: nil, errors: to_errors(changeset.errors, context, domain)}},
+                {{:ok,
+                  %{result: nil, errors: to_errors(changeset.errors, context, domain, resource)}},
                  [changeset, {:error, error}]}
             end
 
           resolution
           |> Absinthe.Resolution.put_result(to_resolution(result, context, domain))
-          |> add_root_errors(domain, modify_args)
+          |> add_root_errors(domain, resource, modify_args)
           |> modify_resolution(modify, modify_args)
         end
 
@@ -1497,7 +1504,7 @@ defmodule AshGraphql.Graphql.Resolver do
           Absinthe.Resolution.put_result(
             resolution,
             to_resolution(
-              {:ok, %{result: nil, errors: to_errors(error, context, domain)}},
+              {:ok, %{result: nil, errors: to_errors(error, context, domain, resource)}},
               context,
               domain
             )
@@ -1616,7 +1623,8 @@ defmodule AshGraphql.Graphql.Resolver do
                               )
                             ],
                             context,
-                            domain
+                            domain,
+                            resource
                           )
                       }},
                      [
@@ -1629,13 +1637,13 @@ defmodule AshGraphql.Graphql.Resolver do
                      ]}
 
                   %Ash.BulkResult{status: :error, errors: errors} ->
-                    {{:ok, %{result: nil, errors: to_errors(errors, context, domain)}},
+                    {{:ok, %{result: nil, errors: to_errors(errors, context, domain, resource)}},
                      [query, {:error, errors}]}
                 end
 
               resolution
               |> Absinthe.Resolution.put_result(to_resolution(result, context, domain))
-              |> add_root_errors(domain, modify_args)
+              |> add_root_errors(domain, resource, modify_args)
               |> modify_resolution(modify, modify_args)
 
             {:error, error} ->
@@ -1663,7 +1671,7 @@ defmodule AshGraphql.Graphql.Resolver do
           Absinthe.Resolution.put_result(
             resolution,
             to_resolution(
-              {:ok, %{result: nil, errors: to_errors(error, context, domain)}},
+              {:ok, %{result: nil, errors: to_errors(error, context, domain, resource)}},
               context,
               domain
             )
@@ -1782,7 +1790,8 @@ defmodule AshGraphql.Graphql.Resolver do
                               )
                             ],
                             context,
-                            domain
+                            domain,
+                            resource
                           )
                       }},
                      [
@@ -1795,13 +1804,13 @@ defmodule AshGraphql.Graphql.Resolver do
                      ]}
 
                   %Ash.BulkResult{status: :error, errors: errors} ->
-                    {{:ok, %{result: nil, errors: to_errors(errors, context, domain)}},
+                    {{:ok, %{result: nil, errors: to_errors(errors, context, domain, resource)}},
                      [query, {:error, errors}]}
                 end
 
               resolution
               |> Absinthe.Resolution.put_result(to_resolution(result, context, domain))
-              |> add_root_errors(domain, modify_args)
+              |> add_root_errors(domain, resource, modify_args)
               |> modify_resolution(modify, modify_args)
 
             {:error, error} ->
@@ -1829,7 +1838,7 @@ defmodule AshGraphql.Graphql.Resolver do
           Absinthe.Resolution.put_result(
             resolution,
             to_resolution(
-              {:ok, %{result: nil, errors: to_errors(error, context, domain)}},
+              {:ok, %{result: nil, errors: to_errors(error, context, domain, resource)}},
               context,
               domain
             )
@@ -2685,35 +2694,35 @@ defmodule AshGraphql.Graphql.Resolver do
     end)
   end
 
-  defp add_root_errors(resolution, domain, {:error, error_or_errors}) do
-    do_root_errors(domain, resolution, error_or_errors)
+  defp add_root_errors(resolution, domain, resource, {:error, error_or_errors}) do
+    do_root_errors(domain, resource, resolution, error_or_errors)
   end
 
-  defp add_root_errors(resolution, domain, [_, {:error, error_or_errors}]) do
-    do_root_errors(domain, resolution, error_or_errors)
+  defp add_root_errors(resolution, domain, resource, [_, {:error, error_or_errors}]) do
+    do_root_errors(domain, resource, resolution, error_or_errors)
   end
 
-  defp add_root_errors(resolution, domain, [_, {:ok, %{errors: errors}}])
+  defp add_root_errors(resolution, domain, resource, [_, {:ok, %{errors: errors}}])
        when errors not in [nil, []] do
-    do_root_errors(domain, resolution, errors, false)
+    do_root_errors(domain, resource, resolution, errors, false)
   end
 
-  defp add_root_errors(resolution, domain, {:ok, %{errors: errors}})
+  defp add_root_errors(resolution, domain, resource, {:ok, %{errors: errors}})
        when errors not in [nil, []] do
-    do_root_errors(domain, resolution, errors, false)
+    do_root_errors(domain, resource, resolution, errors, false)
   end
 
-  defp add_root_errors(resolution, _domain, _other_thing) do
+  defp add_root_errors(resolution, _domain, _resource, _other_thing) do
     resolution
   end
 
-  defp do_root_errors(domain, resolution, error_or_errors, to_errors? \\ true) do
+  defp do_root_errors(domain, resource, resolution, error_or_errors, to_errors? \\ true) do
     if AshGraphql.Domain.Info.root_level_errors?(domain) do
       Map.update!(resolution, :errors, fn current_errors ->
         if to_errors? do
           Enum.concat(
             current_errors || [],
-            List.wrap(to_errors(error_or_errors, resolution.context, domain))
+            List.wrap(to_errors(error_or_errors, resolution.context, domain, resource))
           )
         else
           Enum.concat(current_errors || [], List.wrap(error_or_errors))
@@ -2784,8 +2793,8 @@ defmodule AshGraphql.Graphql.Resolver do
     end)
   end
 
-  defp to_errors(errors, context, domain) do
-    AshGraphql.Errors.to_errors(errors, context, domain)
+  defp to_errors(errors, context, domain, resource) do
+    AshGraphql.Errors.to_errors(errors, context, domain, resource)
   end
 
   def resolve_calculation(%Absinthe.Resolution{state: :resolved} = resolution, _),

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -216,4 +216,17 @@ defmodule AshGraphql.Resource.Info do
 
     is_nil(filterable_fields) or field_name in filterable_fields
   end
+
+  @doc "An error handler for errors produced by the resource"
+  def error_handler(resource) do
+    if resource,
+      do:
+        Extension.get_opt(
+          resource,
+          [:graphql],
+          :error_handler,
+          nil,
+          true
+        )
+  end
 end

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -459,6 +459,13 @@ defmodule AshGraphql.Resource do
         type: {:wrap_list, :atom},
         doc:
           "Mark fields as nullable even if they are required. This is useful when using field policies. See the authorization guide for more."
+      ],
+      error_handler: [
+        type: :mfa,
+        default: {AshGraphql.DefaultErrorHandler, :handle_error, []},
+        doc: """
+        Set an MFA to intercept/handle any errors that are generated.
+        """
       ]
     ],
     sections: [

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -522,4 +522,33 @@ defmodule AshGraphql.ErrorsTest do
 
     assert create_post_mutation["type"]["name"] == "CreatePostResult"
   end
+
+  test "errors can be intercepted at resource level" do
+    variables = %{
+      "input" => %{
+        "name" => "name"
+      }
+    }
+
+    document =
+      """
+      mutation CreateErrorHandling($input: CreateErrorHandlingInput!) {
+        createErrorHandling(input: $input) {
+          result {
+            name
+          }
+          errors{
+            message
+          }
+        }
+      }
+      """
+
+    Absinthe.run(document, AshGraphql.Test.Schema, variables: variables)
+
+    %{data: %{"createErrorHandling" => %{"errors" => [error]}}} =
+      Absinthe.run!(document, AshGraphql.Test.Schema, variables: variables)
+
+    assert error["message"] =~ "replaced!"
+  end
 end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -53,5 +53,6 @@ defmodule AshGraphql.Test.Domain do
     resource(AshGraphql.Test.TextMessage)
     resource(AshGraphql.Test.ImageMessage)
     resource(AshGraphql.Test.Subscribable)
+    resource(AshGraphql.Test.ErrorHandling)
   end
 end

--- a/test/support/resources/error_handling.ex
+++ b/test/support/resources/error_handling.ex
@@ -1,0 +1,43 @@
+defmodule AshGraphql.Test.ErrorHandling do
+  @moduledoc "Example resource with error handling module."
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type :error_handling
+
+    mutations do
+      create :create_error_handling, :create
+    end
+
+    error_handler {ErrorHandler, :handle_error, []}
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:read, :update, :destroy, :create])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute :name, :string do
+      allow_nil?(false)
+      public?(true)
+    end
+  end
+
+  identities do
+    identity(:name, [:name], pre_check_with: AshGraphql.Test.Domain)
+  end
+end
+
+defmodule ErrorHandler do
+  @moduledoc false
+  def handle_error(error, _context) do
+    %{error | message: "replaced!"}
+  end
+end


### PR DESCRIPTION
similarly to error handling in domains, we can allow the `error_handler` option also in resources, so that only errors coming from the specific resource can be customized

### Contributor checklist

- [ ] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
