### PR TITLE
fix: default error handling

### DIFF
--- a/documentation/dsls/DSL-AshGraphql.Resource.md
+++ b/documentation/dsls/DSL-AshGraphql.Resource.md
@@ -72,7 +72,7 @@ end
 | [`generate_object?`](#graphql-generate_object?){: #graphql-generate_object? } | `boolean` | `true` | Whether or not to create the GraphQL object, this allows you to manually create the GraphQL object. |
 | [`filterable_fields`](#graphql-filterable_fields){: #graphql-filterable_fields } | `list(atom)` |  | A list of fields that are allowed to be filtered on. Defaults to all filterable fields for which a GraphQL type can be created. |
 | [`nullable_fields`](#graphql-nullable_fields){: #graphql-nullable_fields } | `atom \| list(atom)` |  | Mark fields as nullable even if they are required. This is useful when using field policies. See the authorization guide for more. |
-| [`error_handler`](#graphql-error_handler){: #graphql-error_handler } | `mfa` | `{AshGraphql.DefaultErrorHandler, :handle_error, []}` | Set an MFA to intercept/handle any errors that are generated. |
+| [`error_handler`](#graphql-error_handler){: #graphql-error_handler } | `mfa` |  | Set an MFA to intercept/handle any errors that are generated. |
 
 
 ## graphql.queries

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -462,7 +462,6 @@ defmodule AshGraphql.Resource do
       ],
       error_handler: [
         type: :mfa,
-        default: {AshGraphql.DefaultErrorHandler, :handle_error, []},
         doc: """
         Set an MFA to intercept/handle any errors that are generated.
         """

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -228,6 +228,7 @@ defmodule AshGraphql.Test.Post do
       create :create_post_with_error, :create_with_error
       create :create_post_with_required_error, :create_with_required_error
       create :create_post, :create_confirm
+      create :create_post_with_length_constraint, :create_with_length_constraint
       create :upsert_post, :upsert, upsert?: true
 
       create :create_post_with_common_map, :create_with_common_map
@@ -297,6 +298,10 @@ defmodule AshGraphql.Test.Post do
 
     create :create_with_error do
       change(RaiseResourceError)
+    end
+
+    create :create_with_length_constraint do
+      validate(string_length(:text, max: 2))
     end
 
     create :create_with_required_error do


### PR DESCRIPTION
Do not apply the default error handler when a custom error handler has been defined on the domain and no error handler was specified on the resource.

The way this was achieved was by not setting the default resource level `error_handler` to `AshGraphql.DefaultErrorHandler`. We already have this behaviour at the domain level, giving the user the experience of the default error handler, by default.

At the resource level, the user has the option to define their own error handler, which is applied, or not.

This bug was causing an issue in our codebase, since we do not want the default error handler applied at all, and we would have had to set it explicitly to `nil` in every resource to get the behaviour we want.

Resolves #260 