### PR TITLE
Add test that exposes failure to traverse nested otherwise unreferenced types

### DIFF
--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -143,4 +143,23 @@ defmodule AshGraphql.ResourceTest do
 
     assert bar_with_foo["type"] == %{"name" => "BarWithFoo", "kind" => "INPUT_OBJECT"}
   end
+
+  test "can create resource with type inside type" do
+    {:ok, %{data: %{"createTypeInsideType" => true}}} =
+      """
+      mutation {
+        unreferencedTypeInsideTypeWorks(input:{
+          typeWithType: {
+            inner_type: {
+              some: "foo",
+              stuff: "bar"
+            },
+            another_field: "baz"
+          }
+        })
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    end
 end

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -54,5 +54,6 @@ defmodule AshGraphql.Test.Domain do
     resource(AshGraphql.Test.ImageMessage)
     resource(AshGraphql.Test.Subscribable)
     resource(AshGraphql.Test.ErrorHandling)
+    resource(AshGraphql.Test.ResourceWithTypeInsideType)
   end
 end

--- a/test/support/resources/resource_with_type_inside_type.ex
+++ b/test/support/resources/resource_with_type_inside_type.ex
@@ -1,0 +1,38 @@
+defmodule AshGraphql.Test.ResourceWithTypeInsideType do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: AshGraphql.Test.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type(:resource_with_type_inside)
+
+
+    queries do
+    end
+
+    mutations do
+      action :create_type_inside_type, :custom_action
+    end
+  end
+
+  actions do
+    default_accept(:*)
+
+    action :custom_action, :boolean do
+      argument :type_with_type, AshGraphql.Test.TypeWithTypeInside, allow_nil?: false
+      run fn _inputs, _ctx ->
+        {:ok, true}
+      end
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:foo, :string, public?: true)
+  end
+
+end

--- a/test/support/types/type_with_type_inside.ex
+++ b/test/support/types/type_with_type_inside.ex
@@ -1,0 +1,25 @@
+defmodule AshGraphql.Test.TypeWithTypeInside do
+  @moduledoc false
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        inner_type: [
+          type: AshGraphql.Test.TypeWithinTypeUnreferencedSubmap,
+          allow_nil?: false
+        ],
+        another_field: [
+          type: :string,
+          allow_nil?: false
+        ]
+      ]
+    ]
+
+  use AshGraphql.Type
+
+  @impl true
+  def graphql_type(_), do: :type_with_type_inside
+
+  @impl true
+  def graphql_input_type(_), do: :type_with_type_inside_input
+end

--- a/test/support/types/type_within_type_unreferenced_submap.ex
+++ b/test/support/types/type_within_type_unreferenced_submap.ex
@@ -1,0 +1,28 @@
+defmodule AshGraphql.Test.TypeWithinTypeUnreferencedSubmap do
+  @moduledoc """
+  This type exists due to a previous bug that types were not traversed
+  properly if used as subtypes and not exposed anywhere directly.
+  """
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        some: [
+          type: :string,
+          allow_nil?: false
+        ],
+        stuff: [
+          type: :string,
+          allow_nil?: false
+        ]
+      ]
+    ]
+
+  use AshGraphql.Type
+
+  @impl true
+  def graphql_type(_), do: :type_within_type_unreferenced_submap
+
+  @impl true
+  def graphql_input_type(_), do: :type_within_type_unreferenced_submap_input
+end


### PR DESCRIPTION
Added test that fails when using a sub-type that is not otherwise exposed in the schema.
Absinthe complains about unreferenced type.
Adding type to any argument will make test pass again.

Or properly traversing type will make test work.
