### PR TITLE
Properly non_null() inner items in list when constraint is supplied for arrays in NewType of :map

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -4639,7 +4639,14 @@ defmodule AshGraphql.Resource do
   end
 
   defp do_field_type({:array, type}, nil, resource, input?, constraints) do
-    field_type = do_field_type(type, nil, resource, input?, constraints[:items] || [])
+    # Due to ash not automatically adding the default array constraints to
+    # types defined outside of an `attribute` we need to default to true here
+    # and not to false.
+    nil_items? = Keyword.get(constraints, :nil_items?, true)
+
+    field_type =
+      do_field_type(type, nil, resource, input?, constraints[:items] || [])
+      |> maybe_wrap_non_null(!nil_items?)
 
     %Absinthe.Blueprint.TypeReference.List{
       of_type: field_type

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3421,7 +3421,7 @@ defmodule AshGraphql.Resource do
                        nil,
                        nil,
                        false,
-                       Keyword.get(constraints, :constraints) || []
+                       Keyword.get(attribute, :constraints) || []
                      )
                    else
                      %Absinthe.Blueprint.TypeReference.NonNull{
@@ -3431,7 +3431,7 @@ defmodule AshGraphql.Resource do
                            nil,
                            nil,
                            false,
-                           Keyword.get(constraints, :constraints) || []
+                           Keyword.get(attribute, :constraints) || []
                          )
                      }
                    end


### PR DESCRIPTION
Fixed two things:
- Pulled constraint from right place (was a bug where it tried to pull constraints from the outer constraints and not from each individual new attribute)
- Utilize the maybe null wrapper and default to not wrapping null unless explicitly supplying nil items

Open question: Maybe we **should** actually default to `nil_items?: false` (as in not use my defensive default to `true`) so that we get the same default setting as for attributes?

It might be confusing that array types does not produce non_null inner items for self defined NewType maps.
Alternatively, that is a bug that needs to be fixed in Ash.
If so then maybe we should make a bug in Ash and reference that bug from this comment I put in?