### PR TITLE
feat: allows `:logger` handlers to know original exception

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -1872,13 +1872,16 @@ defmodule AshGraphql.Graphql.Resolver do
   defp log_exception(e, stacktrace) do
     uuid = Ash.UUID.generate()
 
-    Logger.error("""
-    #{uuid}: Exception raised while resolving query.
+    Logger.error(
+      """
+      #{uuid}: Exception raised while resolving query.
 
-    #{String.slice(Exception.format(:error, e), 0, 2000)}
+      #{String.slice(Exception.format(:error, e), 0, 2000)}
 
-    #{Exception.format_stacktrace(stacktrace)}
-    """)
+      #{Exception.format_stacktrace(stacktrace)}
+      """,
+      crash_reason: {e, stacktrace}
+    )
 
     uuid
   end


### PR DESCRIPTION
### Contributor checklist

- [x] Features include unit/acceptance tests


---

Hey there :wave: 

Thanks for working on ash!

Similar report  to https://github.com/mtrudel/bandit/issues/413.

`crash_reason` metadata useful for `Logger` [handlers](https://hexdocs.pm/logger/main/Logger.html#module-erlang-otp-handlers), so that they can receive the original exception values in addition to the formatted error string.

Discovered this while testing [`tower`](https://github.com/mimiquate/tower) alongside `ash`, but this could be useful for any other exception tracker using a `:logger` handler.

Elixir Logger docs:
https://hexdocs.pm/logger/1.17.3/Logger.html#module-metadata

![image](https://github.com/user-attachments/assets/2048a839-1a8f-45af-8360-a344a3fc6486)

Examples:
- `plug_cowboy`
  - https://github.com/elixir-plug/plug_cowboy/blob/ced253f035f2a07ebed17cfacb64d4f16357a750/lib/plug/cowboy/translator.ex#L42-L46
  - https://github.com/elixir-plug/plug_cowboy/blob/ced253f035f2a07ebed17cfacb64d4f16357a750/lib/plug/cowboy/translator.ex#L64
  - https://github.com/elixir-plug/plug_cowboy/blob/ced253f035f2a07ebed17cfacb64d4f16357a750/lib/plug/cowboy/handler.ex#L52-L63
- `broadway`
  - https://github.com/dashbitco/broadway/blob/9eaf2140b6c1f36b25f990a7c74052bece26aadc/lib/broadway/acknowledger.ex#L108-L110
  - https://github.com/dashbitco/broadway/blob/9eaf2140b6c1f36b25f990a7c74052bece26aadc/lib/broadway/acknowledger.ex#L88-L91
- `db_connection`
  - https://github.com/elixir-ecto/db_connection/blob/c6dcdf92a205e02da2468258085bc0792d39df09/lib/db_connection.ex#L1728-L1744
- `nimble_pool`
  - https://github.com/dashbitco/nimble_pool/blob/64a3b081dc804bbe214ad739a7c5a5c2c298c086/lib/nimble_pool.ex#L1081-L1101
- `quantum`
  - https://github.com/quantum-elixir/quantum-core/blob/3e3ccb911c54b9784c5ff44c2fabf3664577a6e1/lib/quantum/executor.ex#L141-L150  

Related discussion in mailing list: https://groups.google.com/g/elixir-lang-core/c/pWz-uTVMEVM.