### PR TITLE
fix: handle invalid query error different formats

### DIFF
--- a/lib/error.ex
+++ b/lib/error.ex
@@ -16,12 +16,7 @@ end
 
 defimpl AshGraphql.Error, for: Ash.Error.Query.InvalidQuery do
   def to_error(error) do
-    error_fields =
-      if is_nil(error.field) do
-        Map.get(error, :fields, [])
-      else
-        [error.field]
-      end
+    fields = List.wrap(error.field || Map.get(error, :fields) || [])
 
     %{
       message: error.message,

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -16,12 +16,19 @@ end
 
 defimpl AshGraphql.Error, for: Ash.Error.Query.InvalidQuery do
   def to_error(error) do
+    error_fields =
+      if is_nil(error.field) do
+        Map.get(error, :fields, [])
+      else
+        [error.field]
+      end
+
     %{
       message: error.message,
       short_message: error.message,
       vars: Map.new(error.vars),
       code: "invalid_query",
-      fields: [error.field]
+      fields: error_fields
     }
   end
 end

--- a/lib/error.ex
+++ b/lib/error.ex
@@ -23,7 +23,7 @@ defimpl AshGraphql.Error, for: Ash.Error.Query.InvalidQuery do
       short_message: error.message,
       vars: Map.new(error.vars),
       code: "invalid_query",
-      fields: error_fields
+      fields: fields
     }
   end
 end

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -667,4 +667,32 @@ defmodule AshGraphql.ErrorsTest do
 
     assert error["message"] == "replaced! update"
   end
+
+  test "errors are transformed into correct responses" do
+    message = "incorrect email"
+
+    errors =
+      AshGraphql.Errors.to_errors(
+        [
+          Ash.Error.Query.InvalidQuery.exception(
+            field: :email,
+            message: message
+          )
+        ],
+        %{},
+        AshGraphql.Test.Domain,
+        nil,
+        nil
+      )
+
+    assert [
+             %{
+               code: "invalid_query",
+               message: message,
+               fields: [:email],
+               vars: %{},
+               short_message: message
+             }
+           ] == errors
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/ash-project/ash/pull/1960. Handle both `field` and `fields` in `InvalidQuery` error.

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
