### PR TITLE
Support for returning relay encoded id when subscribing to destroy events

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -249,7 +249,8 @@ defmodule AshGraphql do
                 all_domains,
                 unquote(resources),
                 action_middleware,
-                unquote(schema)
+                unquote(schema),
+                unquote(relay_ids?)
               )
               |> Enum.reduce(blueprint_with_mutations, fn subscription, blueprint ->
                 Absinthe.Blueprint.add_field(blueprint, "RootSubscriptionType", subscription)

--- a/lib/domain/domain.ex
+++ b/lib/domain/domain.ex
@@ -251,7 +251,7 @@ defmodule AshGraphql.Domain do
     )
   end
 
-  def subscriptions(domain, all_domains, resources, action_middleware, schema) do
+  def subscriptions(domain, all_domains, resources, action_middleware, schema, relay_ids?) do
     resources
     |> Enum.filter(fn resource ->
       AshGraphql.Resource in Spark.extensions(resource)
@@ -262,7 +262,8 @@ defmodule AshGraphql.Domain do
         all_domains,
         &1,
         action_middleware,
-        schema
+        schema,
+        relay_ids?
       )
     )
   end

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -554,7 +554,7 @@ defmodule AshGraphql.Graphql.Resolver do
   def resolve(
         %{arguments: args, context: context, root_value: notifications} = resolution,
         {domain, resource,
-         %AshGraphql.Resource.Subscription{read_action: read_action, name: name}, _input?}
+         %AshGraphql.Resource.Subscription{read_action: read_action, name: name}, relay_ids?}
       )
       when is_list(notifications) do
     case handle_arguments(resource, read_action, args) do
@@ -674,7 +674,7 @@ defmodule AshGraphql.Graphql.Resolver do
                 end
               else
                 Enum.map(notifications, fn notification ->
-                  %{key => AshGraphql.Resource.encode_id(notification.data, false)}
+                  %{key => AshGraphql.Resource.encode_id(notification.data, relay_ids?)}
                 end)
               end
             end)
@@ -711,7 +711,7 @@ defmodule AshGraphql.Graphql.Resolver do
   def resolve(
         %{arguments: args, context: context, root_value: notification} = resolution,
         {domain, resource,
-         %AshGraphql.Resource.Subscription{read_action: read_action, name: name}, _input?}
+         %AshGraphql.Resource.Subscription{read_action: read_action, name: name}, relay_ids?}
       ) do
     case handle_arguments(resource, read_action, args) do
       {:ok, args} ->
@@ -831,7 +831,7 @@ defmodule AshGraphql.Graphql.Resolver do
                  %{
                    String.to_existing_atom(
                      subcription_field_from_action_type(notification.action_type)
-                   ) => AshGraphql.Resource.encode_id(notification.data, false)
+                   ) => AshGraphql.Resource.encode_id(notification.data, relay_ids?)
                  }}
               )
           end

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -1326,7 +1326,7 @@ defmodule AshGraphql.Resource do
   # sobelow_skip ["DOS.StringToAtom"]
   @doc false
 
-  def subscriptions(domain, all_domains, resource, action_middleware, schema) do
+  def subscriptions(domain, all_domains, resource, action_middleware, schema, relay_ids?) do
     resource
     |> subscriptions(all_domains)
     |> Enum.map(fn %Subscription{name: name, hide_inputs: hide_inputs} = subscription ->
@@ -1351,7 +1351,8 @@ defmodule AshGraphql.Resource do
           action_middleware ++
             domain_middleware(domain) ++
             [
-              {{AshGraphql.Graphql.Resolver, :resolve}, {domain, resource, subscription, true}}
+              {{AshGraphql.Graphql.Resolver, :resolve},
+               {domain, resource, subscription, relay_ids?}}
             ],
         type: result_type,
         __reference__: ref(__ENV__)

--- a/test/support/relay_domain.ex
+++ b/test/support/relay_domain.ex
@@ -1,0 +1,16 @@
+defmodule AshGraphql.Test.RelayDomain do
+  @moduledoc false
+
+  use Ash.Domain,
+    extensions: [
+      AshGraphql.Domain
+    ],
+    otp_app: :ash_grapqhl
+
+  graphql do
+  end
+
+  resources do
+    resource(AshGraphql.Test.RelaySubscribable)
+  end
+end

--- a/test/support/relay_schema.ex
+++ b/test/support/relay_schema.ex
@@ -1,0 +1,21 @@
+defmodule AshGraphql.Test.RelaySchema do
+  @moduledoc false
+
+  use Absinthe.Schema
+
+  @domains [AshGraphql.Test.RelayDomain]
+
+  use AshGraphql,
+    domains: @domains,
+    relay_ids?: true,
+    generate_sdl_file: "priv/schema-relay.graphql"
+
+  query do
+  end
+
+  mutation do
+  end
+
+  subscription do
+  end
+end

--- a/test/support/resources/relay_subscribable.ex
+++ b/test/support/resources/relay_subscribable.ex
@@ -1,0 +1,85 @@
+defmodule AshGraphql.Test.RelaySubscribable do
+  @moduledoc false
+  use Ash.Resource,
+    domain: AshGraphql.Test.RelayDomain,
+    data_layer: Ash.DataLayer.Ets,
+    authorizers: [Ash.Policy.Authorizer],
+    extensions: [AshGraphql.Resource]
+
+  require Ash.Query
+
+  graphql do
+    type :relay_subscribable
+
+    mutations do
+      destroy :destroy_subscribable_relay, :destroy
+    end
+
+    subscriptions do
+      pubsub(AshGraphql.Test.PubSub)
+
+      subscribe(:subscribable_events_relay) do
+        action_types([:create, :update, :destroy])
+      end
+
+      subscribe(:subscribable_deleted_relay) do
+        action_types(:destroy)
+      end
+    end
+  end
+
+  policies do
+    bypass actor_attribute_equals(:role, :admin) do
+      authorize_if(always())
+    end
+
+    policy action(:read) do
+      authorize_if(expr(actor_id == ^actor(:id)))
+    end
+
+    policy action([:open_read, :read_with_arg]) do
+      authorize_if(always())
+    end
+  end
+
+  field_policies do
+    field_policy :hidden_field do
+      authorize_if(actor_attribute_equals(:role, :admin))
+    end
+
+    field_policy :* do
+      authorize_if(always())
+    end
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+
+    read(:open_read)
+
+    read :read_with_arg do
+      argument(:topic, :string) do
+        allow_nil? false
+      end
+
+      filter(expr(topic == ^arg(:topic)))
+    end
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:hidden_field, :string) do
+      public?(true)
+      default("hidden")
+      allow_nil?(false)
+    end
+
+    attribute(:text, :string, public?: true)
+    attribute(:topic, :string, public?: true)
+    attribute(:actor_id, :integer, public?: true)
+    create_timestamp(:created_at)
+    update_timestamp(:updated_at)
+  end
+end


### PR DESCRIPTION
Closes #306 

Currently, if attempting to subscribe to a destroy event, the message that is received has the shape of something like:

```json
"myResource": {
  "destroyed": "{myUUID}"
}
```

However, if a user has a schema with `relay_ids?: true`, this is the wrong type of ID, as it doesn't get encoded as a relay id.

This PR addresses that by passing the `relay_ids?` value down through the domains and resources, and eventually to the `resolve/2` function which gets added to the Absinthe middleware. When encoding the id for a `:destroy` action, the `relay_ids?` setting will now be respected.

---

#### Tests
I couldn't find a way to change the `relay_ids?` value at runtime during the test, so this unfortunately requires setting up a whole new `RelaySchema` and associated `RelayDomain` and `RelaySubscribable` resource. While verbose, this seemed like the most straight forward way to keep existing tests and schema in place.

### Contributor checklist

- [x] Bug fixes include regression tests
- [x] Features include unit/acceptance tests
