### PR TITLE
Reproduce `(KeyError) key :to_tenant not found in: nil`

### DIFF
--- a/test/gf_test.exs
+++ b/test/gf_test.exs
@@ -1,0 +1,75 @@
+defmodule GF.Test do
+  use ExUnit.Case
+
+  test "basic" do
+    group =
+      GF.Group
+      |> Ash.Changeset.for_create(:create, %{abbreviation: "TG", name: "Test Group"})
+      |> Ash.create!(authorize?: false)
+
+    Ash.DataLayer.Simple.set_data(GF.Group, [group])
+
+    event =
+      GF.Event
+      |> Ash.Changeset.for_create(:create, %{title: "Test Event"}, tenant: group.id)
+      |> Ash.create!(authorize?: false)
+
+    assert event.id
+
+    Ash.DataLayer.Simple.set_data(GF.Event, [event])
+
+    assert Ash.get!(GF.Event, event.id, authorize?: false)
+
+    member =
+      GF.Member
+      |> Ash.Changeset.for_create(
+        :create,
+        %{email: "test@example.com", name: "Test Member", status: :active},
+        tenant: group.id
+      )
+      |> Ash.create!(authorize?: false)
+
+    actor =
+      GF.Member
+      |> Ash.Changeset.for_create(
+        :create,
+        %{email: "actor@example.com", name: "Actor Member", status: :inactive},
+        tenant: group.id
+      )
+      |> Ash.create!(authorize?: false)
+
+    Ash.DataLayer.Simple.set_data(GF.Member, [member, actor])
+
+    attendee =
+      GF.Attendee
+      |> Ash.Changeset.for_create(:create, %{event_id: event.id, member_id: member.id})
+      |> Ash.create!(authorize?: false)
+
+    Ash.DataLayer.Simple.set_data(GF.Attendee, [attendee])
+
+    assert attendee.id
+
+    {:ok, %{data: data}} =
+      """
+      query GetEvent($id: ID!) {
+        getEvent(id: $id) {
+          id
+          title
+          attendees(filter: {member: {status: {eq: ACTIVE}}}) {
+            id
+            member {
+              id
+              name
+            }
+          }
+        }
+      }
+      """
+      |> Absinthe.run(GF.AshGraphqlSchema,
+        variables: %{"id" => event.id},
+        context: %{actor: actor}
+      )
+
+    assert data["getEvent"]
+  end
+end

--- a/test/support/gf/active_member_policy.ex
+++ b/test/support/gf/active_member_policy.ex
@@ -1,0 +1,28 @@
+defmodule GF.ActiveMemberPolicy do
+  use Ash.Policy.SimpleCheck
+
+  # This is used when logging a breakdown of how a policy is applied - see Logging below.
+  def describe(_) do
+    "Member is active and has given role"
+  end
+
+  def match?(%_{} = member, %{resource: _resource} = _context, opts) do
+    active? =
+      case member do
+        %{status: :active} -> true
+        _other -> false
+      end
+
+    cond do
+      opts[:role] ->
+        GF.Member.can_take_role_action?(member, opts[:role])
+
+      true ->
+        active?
+    end
+  end
+
+  def match?(_actor, _context, _opts) do
+    false
+  end
+end

--- a/test/support/gf/ash_graphql_schema.ex
+++ b/test/support/gf/ash_graphql_schema.ex
@@ -1,0 +1,15 @@
+defmodule GF.AshGraphqlSchema do
+  @moduledoc false
+
+  use Absinthe.Schema
+
+  @domains [GF.Domain]
+
+  use AshGraphql, domains: @domains, generate_sdl_file: "priv/gf_schema.graphql"
+
+  query do
+  end
+
+  mutation do
+  end
+end

--- a/test/support/gf/attendee.ex
+++ b/test/support/gf/attendee.ex
@@ -1,0 +1,51 @@
+defmodule GF.Attendee do
+  @moduledoc """
+  An attendee record for ane event.
+  """
+
+  use Ash.Resource,
+    domain: GF.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
+
+  require Ash.Query
+  require Ash.Sort
+
+  alias GF.Member
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :update, :read, :destroy])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:event_id, :uuid, public?: true)
+    attribute(:member_id, :uuid, public?: true)
+
+    create_timestamp(:inserted_at)
+    update_timestamp(:updated_at)
+  end
+
+  relationships do
+    belongs_to(:member, Member, public?: true)
+  end
+
+  policies do
+    policy action(:read) do
+      authorize_if(actor_present())
+    end
+  end
+
+  graphql do
+    type :gf_attendee
+  end
+
+  code_interface do
+    define(:get_by_id, action: :read, get_by: :id, not_found_error?: false)
+    define(:create, action: :create)
+    define(:update, action: :update)
+  end
+end

--- a/test/support/gf/domain.ex
+++ b/test/support/gf/domain.ex
@@ -1,0 +1,10 @@
+defmodule GF.Domain do
+  use Ash.Domain
+
+  resources do
+    resource(GF.Event)
+    resource(GF.Attendee)
+    resource(GF.Group)
+    resource(GF.Member)
+  end
+end

--- a/test/support/gf/event.ex
+++ b/test/support/gf/event.ex
@@ -1,0 +1,55 @@
+defmodule GF.Event do
+  @moduledoc """
+  Event Ash resource.
+  """
+
+  use Ash.Resource,
+    domain: GF.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  require Ash.Query
+
+  alias GF.Attendee
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:description, :string, public?: true)
+    attribute(:group_id, :uuid, public?: false)
+
+    attribute(:start_at, :utc_datetime, public?: true)
+    attribute(:title, :string, public?: true)
+
+    create_timestamp(:inserted_at, public?: true)
+    update_timestamp(:updated_at, public?: true)
+  end
+
+  multitenancy do
+    strategy(:attribute)
+    attribute(:group_id)
+    global?(true)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  relationships do
+    has_many(:attendees, Attendee, public?: true)
+  end
+
+  graphql do
+    type :gf_event
+
+    queries do
+      get :get_event, :read
+    end
+  end
+
+  code_interface do
+    define(:get_by_id, action: :read, get_by: :id, not_found_error?: false)
+    define(:create, action: :create)
+  end
+end

--- a/test/support/gf/group.ex
+++ b/test/support/gf/group.ex
@@ -1,0 +1,35 @@
+defmodule GF.Group do
+  @moduledoc "An Ash-managed GroupFlow Group (customer)"
+
+  use Ash.Resource,
+    domain: GF.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  @type t :: %__MODULE__{}
+
+  # Attributes are the simple pieces of data that exist on your resource
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:abbreviation, :string, public?: true)
+    attribute(:name, :string, public?: true)
+
+    create_timestamp(:inserted_at, public?: true)
+    update_timestamp(:updated_at, public?: true)
+  end
+
+  actions do
+    default_accept(:*)
+    # Add a set of simple actions. You'll customize these later.
+    defaults([:create, :read, :update, :destroy])
+  end
+
+  graphql do
+    type :group2
+  end
+
+  code_interface do
+    define(:create, action: :create)
+  end
+end

--- a/test/support/gf/member.ex
+++ b/test/support/gf/member.ex
@@ -1,0 +1,158 @@
+defmodule GF.Member do
+  use Ash.Resource,
+    domain: GF.Domain,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource],
+    authorizers: [Ash.Policy.Authorizer]
+
+  require Ash.Query
+  require Logger
+
+  alias GF.ActiveMemberPolicy
+  alias GF.Group
+  alias GF.Types.MemberStatus
+
+  @roles_options [
+    admin: "Admin Site",
+    content: "Content Management",
+    developer: "Developer",
+    elections: "Elections",
+    events: "Events",
+    finances: "Finances",
+    forum: "Forum Moderatrion",
+    group_announcements: "Group Announcements",
+    members: "Members Management",
+    super: "Superuser"
+  ]
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute(:email, :string, public?: true)
+    attribute(:group_id, :uuid, public?: false)
+
+    attribute(:name, :string,
+      default: "",
+      allow_nil?: false,
+      constraints: [allow_empty?: true],
+      public?: true
+    )
+
+    attribute :roles, {:array, :string} do
+      default([])
+      public?(true)
+    end
+
+    attribute(:status, MemberStatus, public?: true)
+
+    create_timestamp(:inserted_at, public?: true)
+    update_timestamp(:updated_at)
+  end
+
+  relationships do
+    belongs_to(:group, Group, public?: true)
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:create, :read, :destroy, :update])
+  end
+
+  multitenancy do
+    strategy(:attribute)
+    attribute(:group_id)
+
+    global?(true)
+  end
+
+  policies do
+    bypass {ActiveMemberPolicy, role: :members} do
+      authorize_if(always())
+    end
+
+    policy action(:read) do
+      authorize_if(expr(id == ^actor(:id)))
+      authorize_if({ActiveMemberPolicy, []})
+    end
+  end
+
+  @any_member_fields [
+    :name,
+    :status
+  ]
+
+  @member_self_fields @any_member_fields ++
+                        [
+                          :email,
+                          :inserted_at,
+                          :roles
+                        ]
+
+  #  Note: field_policies are only considered for _reading_ data.
+  field_policies do
+    field_policy_bypass @member_self_fields, actor_attribute_equals(:__struct__, __MODULE__) do
+      authorize_if(expr(id == ^actor(:id)))
+      forbid_if(always())
+    end
+
+    field_policy_bypass @member_self_fields do
+      authorize_if(expr(id == ^actor(:id)))
+    end
+
+    field_policy @any_member_fields do
+      authorize_if({ActiveMemberPolicy, []})
+    end
+  end
+
+  graphql do
+    type :gf_member
+  end
+
+  code_interface do
+    define(:create, action: :create)
+    define(:get_by_id, action: :read, get_by: :id, not_found_error?: false)
+  end
+
+  def can_take_role_action?(%{status: :active} = member, role) do
+    has_any_role_access?(member, role)
+  end
+
+  def can_take_role_action?(_member_or_nil, _role) do
+    false
+  end
+
+  def has_any_role_access?(member, roles) when is_list(roles) do
+    Enum.any?(roles, &has_role_access?(member, &1))
+  end
+
+  def has_any_role_access?(member, role) when is_atom(role) do
+    has_role_access?(member, role)
+  end
+
+  def has_role_access?(%{} = member, role) when is_atom(role) do
+    active? = member.status == :active
+
+    cond do
+      @roles_options[role] == nil ->
+        Logger.warning("Unrecognized role: #{inspect(role)}")
+        false
+
+      active? == false ->
+        false
+
+      to_string(role) in member.roles ->
+        true
+
+      role == :admin and Enum.any?(member.roles) ->
+        true
+
+      "super" in member.roles and role != :developer ->
+        true
+
+      true ->
+        false
+    end
+  end
+
+  def has_role_access?(_other, _role), do: false
+end

--- a/test/support/gf/types/member_status.ex
+++ b/test/support/gf/types/member_status.ex
@@ -1,0 +1,6 @@
+defmodule GF.Types.MemberStatus do
+  use Ash.Type.Enum, values: [:non_member, :inactive, :active, :banned]
+
+  def graphql_type(_), do: :sample_member_status
+  def graphql_input_type(_), do: :sample_member_status
+end


### PR DESCRIPTION
### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

Elixir Forum reference: https://elixirforum.com/t/not-found-in-nil-exception-after-ash-upgrade/70722/15

```
15:17:28.414 [error] 4291beb8-4a54-4fb1-b9bd-cdd57dba42b1: Exception raised while resolving query.

** (Ash.Error.Unknown) 
Bread Crumbs:
  > Exception raised in: GF.Event.read> Exception raised in: GF.Attendee.read

Unknown Error

* ** (KeyError) key :to_tenant not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
  (ash 3.5.8) lib/ash/policy/check/expression.ex:3: Ash.Policy.Check.Expression.try_strict_check/3
  (ash 3.5.8) lib/ash/policy/policy.ex:183: Ash.Policy.Policy.fetch_or_strict_check_fact/2
  (ash 3.5.8) lib/ash/policy/policy.ex:431: Ash.Policy.Policy.handle_constants/2
  (ash 3.5.8) lib/ash/policy/policy.ex:404: Ash.Policy.Policy.handle_constants/2
  (ash 3.5.8) lib/ash/policy/policy.ex:390: Ash.Policy.Policy.handle_constants/2
  (ash 3.5.8) lib/ash/policy/policy.ex:404: Ash.Policy.Policy.handle_constants/2
  (ash 3.5.8) lib/ash/policy/policy.ex:390: Ash.Policy.Policy.handle_constants/2
  (ash 3.5.8) lib/ash/policy/policy.ex:29: Ash.Policy.Policy.solve/1
  (ash 3.5.8) lib/ash/policy/checker.ex:65: Ash.Policy.Checker.strict_check_scenarios/1
  (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1696: Ash.Policy.Authorizer.strict_check_result/2
  (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1119: Ash.Policy.Authorizer.field_condition/5
  (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1082: Ash.Policy.Authorizer.expression_for_ref/6
  (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1006: Ash.Policy.Authorizer.replace_refs/2
  (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:972: Ash.Policy.Authorizer.replace_refs/2
  (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:734: Ash.Policy.Authorizer.alter_filter/3
  (ash 3.5.8) lib/ash/can.ex:481: Ash.Can.alter_query/5
  (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
  (ash 3.5.8) lib/ash.ex:1390: Ash.can/3
  (ash 3.5.8) lib/ash/actions/read/read.ex:1415: Ash.Actions.Read.authorize_query/2
  (ash 3.5.8) lib/ash/actions/read/read.ex:472: Ash.Actions.Read.do_read/5

    (ash 3.5.8) lib/ash/policy/check/expression.ex:3: Ash.Policy.Check.Expression.try_strict_check/3
    (ash 3.5.8) lib/ash/policy/policy.ex:183: Ash.Policy.Policy.fetch_or_strict_check_fact/2
    (ash 3.5.8) lib/ash/policy/policy.ex:431: Ash.Policy.Policy.handle_constants/2
    (ash 3.5.8) lib/ash/policy/policy.ex:404: Ash.Policy.Policy.handle_constants/2
    (ash 3.5.8) lib/ash/policy/policy.ex:390: Ash.Policy.Policy.handle_constants/2
    (ash 3.5.8) lib/ash/policy/policy.ex:404: Ash.Policy.Policy.handle_constants/2
    (ash 3.5.8) lib/ash/policy/policy.ex:390: Ash.Policy.Policy.handle_constants/2
    (ash 3.5.8) lib/ash/policy/policy.ex:29: Ash.Policy.Policy.solve/1
    (ash 3.5.8) lib/ash/policy/checker.ex:65: Ash.Policy.Checker.strict_check_scenarios/1
    (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1696: Ash.Policy.Authorizer.strict_check_result/2
    (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1119: Ash.Policy.Authorizer.field_condition/5
    (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1082: Ash.Policy.Authorizer.expression_for_ref/6
    (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:1006: Ash.Policy.Authorizer.replace_refs/2
    (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:972: Ash.Policy.Authorizer.replace_refs/2
    (ash 3.5.8) lib/ash/policy/authorizer/authorizer.ex:734: Ash.Policy.Authorizer.alter_filter/3
    (ash 3.5.8) lib/ash/can.ex:481: Ash.Can.alter_query/5
    (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ash 3.5.8) lib/ash.ex:1390: Ash.can/3
    (ash 3.5.8) lib/ash/actions/read/read.ex:1415: Ash.Actions.Read.authorize_query/2
    (ash 3.5.8) lib/ash/actions/read/read.ex:472: Ash.Actions.Read.do_read/5




  1) test basic (GF.Test)
     test/gf_test.exs:4
     Expected truthy, got nil
     code: assert data["getEvent"]
     arguments:

         # 1
         %{"getEvent" => nil}

         # 2
         "getEvent"

     stacktrace:
       test/gf_test.exs:73: (test)
```