### PR TITLE
fix: change default playground interface

### DIFF
--- a/lib/igniter.ex
+++ b/lib/igniter.ex
@@ -194,7 +194,7 @@ if Code.ensure_loaded?(Igniter) do
                   Absinthe.Plug.GraphiQL,
                   schema: Module.concat(["#{inspect(schema_name)}"]),
                   socket: Module.concat(["#{inspect(socket_name)}"]),
-                  interface: :playground
+                  interface: :simple
 
           forward "/",
             Absinthe.Plug,

--- a/test/mix/tasks/ash_graphql_install_test.exs
+++ b/test/mix/tasks/ash_graphql_install_test.exs
@@ -133,7 +133,7 @@ defmodule Mix.Tasks.AshGraphqlInstallTest do
       + |    forward("/playground", Absinthe.Plug.GraphiQL,
       + |      schema: Module.concat(["TestWeb.GraphqlSchema"]),
       + |      socket: Module.concat(["TestWeb.GraphqlSocket"]),
-      + |      interface: :playground
+      + |      interface: :simple
       + |    )
       + |
       + |    forward("/", Absinthe.Plug, schema: Module.concat(["TestWeb.GraphqlSchema"]))


### PR DESCRIPTION
Previously, the default playground interface was set to `:playground` which uses graphql-playground. However, this uses a deprecated JavaScript API which means that it does not work on modern versions of chrome. It also seems that the library is no longer maintained, so the chances of this being fixed in a future release are slim.

The result of this, is that tooltips do not disappear, making the application seem broken. Whilst this isn't a direct issue of this library, I think it gives a bad impression when things are broken out of the box.

This commit changes the generated interface to graphiql (using the `:simple` interface). There is also an `:advanced` interface option, but that also points to an unmaintained library which didn't work out of the box.

https://github.com/graphql/graphql-playground/issues/1429

Sorry @sevenseacat this might mean the screenshots in the book need updating.