### PR TITLE
fix: handling of attribute with array type in middleware for field function

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -3087,23 +3087,6 @@ defmodule AshGraphql.Graphql.Resolver do
 
   defp resolve_union_result(
          value,
-         {name, _field_type, %{type: {:array, field_type}} = field, resource, unnested_types,
-          domain}
-       ) do
-    if value do
-      Enum.map(
-        value,
-        &resolve_union_result(
-          &1,
-          {name, field_type, %{field | type: field_type, constraints: field.constraints[:items]},
-           resource, unnested_types, domain}
-        )
-      )
-    end
-  end
-
-  defp resolve_union_result(
-         value,
          {name, {:array, field_type}, field, resource, unnested_types, domain}
        ) do
     if value do

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -3087,6 +3087,23 @@ defmodule AshGraphql.Graphql.Resolver do
 
   defp resolve_union_result(
          value,
+         {name, _field_type, %{type: {:array, field_type}} = field, resource, unnested_types,
+          domain}
+       ) do
+    if value do
+      Enum.map(
+        value,
+        &resolve_union_result(
+          &1,
+          {name, field_type, %{field | type: field_type, constraints: field.constraints[:items]},
+           resource, unnested_types, domain}
+        )
+      )
+    end
+  end
+
+  defp resolve_union_result(
+         value,
          {name, {:array, field_type}, field, resource, unnested_types, domain}
        ) do
     if value do

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -4590,7 +4590,13 @@ defmodule AshGraphql.Resource do
   end
 
   defp middleware_for_field(resource, field, name, {:array, type}, constraints, domain) do
-    middleware_for_field(resource, field, name, type, constraints, domain)
+    case middleware_for_field(resource, field, name, type, constraints, domain) do
+      [{middleware, {name, type, field, resource, unnested_types, domain}}] ->
+        [{middleware, {name, {:array, type}, field, resource, unnested_types, domain}}]
+
+      middleware ->
+        middleware
+    end
   end
 
   defp middleware_for_field(resource, field, name, type, constraints, domain) do


### PR DESCRIPTION
# Contributor checklist

In a simple data layer, a resource with an array-type attribute does not properly set the middleware fields correctly. i.e.,

```
attribute :results, {:array, UnionType} do
  ....
end
```

- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
