### PR TITLE
Bug: `argument_input_types foo: :string` is ignored

### DIFF
--- a/test/create_test.exs
+++ b/test/create_test.exs
@@ -551,6 +551,39 @@ defmodule AshGraphql.CreateTest do
     assert %{data: %{"createPost" => %{"result" => %{"text" => "foobar"}}}} = result
   end
 
+  test "a create with argument_input_type works" do
+    resp =
+      """
+      mutation CreatePostWithArgumentTypes($input: CreatePostWithArgumentTypesInput!) {
+        createPostWithArgumentTypes(input: $input) {
+          result {
+            text
+          }
+          errors {
+            message
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema,
+        variables: %{
+          "input" => %{
+            "integerArgumentAsString" => "1"
+          }
+        }
+      )
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    assert %{
+             data: %{
+               "createPostWithArgumentTypes" => %{"result" => %{}}
+             }
+           } = result
+  end
+
   test "a create with a fragment works" do
     resp =
       """

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -165,7 +165,9 @@ defmodule AshGraphql.Test.Post do
 
     attribute_types integer_as_string_in_domain: :string
     attribute_input_types integer_as_string_in_domain: :string
-    argument_input_types create_bar_with_foo_with_map: [bar: :bar_with_foo]
+
+    argument_input_types create_bar_with_foo_with_map: [bar: :bar_with_foo],
+                         integer_argument_as_string: :string
 
     argument_names create_with_invalid_arguments_names: [
                      invalid_1: :invalid1,
@@ -227,6 +229,7 @@ defmodule AshGraphql.Test.Post do
     mutations do
       create :simple_create_post, :create
       create :create_post_with_arg, :create, args: [:text]
+      create :create_post_with_argument_types, :create_with_argument_types
       create :create_post_with_error, :create_with_error
       create :create_post_with_required_error, :create_with_required_error
       create :create_post, :create_confirm
@@ -316,6 +319,10 @@ defmodule AshGraphql.Test.Post do
     create :create_with_invalid_arguments_names do
       argument(:invalid_1, :string)
       argument(:remove_invalid?, :boolean, allow_nil?: false, default: true)
+    end
+
+    create :create_with_argument_types do
+      argument(:integer_argument_as_string, :integer)
     end
 
     create :upsert do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Defining an argument and argument_input_type like this:

```elixir
argument :foo, :integer

argument_input_types foo: :string
```

Results in the error:

```
Argument "input" has invalid value $input.
In field "foo": Expected type "Int", found "1".
```