### PR TITLE
fix: fix :none relationship pagination strategy, and improve tests for it

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -2287,7 +2287,7 @@ defmodule AshGraphql.Graphql.Resolver do
           nested = Enum.map(Enum.reverse([selection | path]), & &1.name)
 
           related_query =
-            if pagination_strategy do
+            if pagination_strategy && pagination_strategy != :none do
               case page_opts(
                      resolution,
                      relationship.destination,

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -1563,6 +1563,10 @@ defmodule AshGraphql.Resource do
 
   defp pagination_strategy(strategy, action, allow_relay? \\ false)
 
+  defp pagination_strategy(:none, _action, _allow_relay?) do
+    :none
+  end
+
   defp pagination_strategy(_strategy, %{pagination: pagination}, _allow_relay?)
        when pagination in [nil, false] do
     nil
@@ -4495,7 +4499,8 @@ defmodule AshGraphql.Resource do
     end)
   end
 
-  defp related_list_type(nil, type, resource, relationship) do
+  defp related_list_type(value, type, resource, relationship)
+       when is_nil(value) or value == :none do
     inner_type = %Absinthe.Blueprint.TypeReference.List{
       of_type: %Absinthe.Blueprint.TypeReference.NonNull{
         of_type: type

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -193,13 +193,10 @@ defmodule AshGraphql.Test.Post do
     field_names text_1_and_2: :text1_and2
     keyset_field :keyset
 
+    paginate_relationship_with unpaginated_comments: :none
+
     queries do
       get :get_post, :read
-
-      get :get_post_with_no_comment_pagination, :read do
-        paginate_relationship_with(comments: :none)
-      end
-
       get :get_post_with_custom_description, :read, description: "A custom description"
       list :post_library, :library
       list :paginated_posts, :paginated
@@ -656,6 +653,11 @@ defmodule AshGraphql.Test.Post do
     has_many(:comments, AshGraphql.Test.Comment, public?: true)
     has_many(:sponsored_comments, AshGraphql.Test.SponsoredComment, public?: true)
     has_many(:paginated_comments, AshGraphql.Test.Comment, read_action: :paginated, public?: true)
+
+    has_many(:unpaginated_comments, AshGraphql.Test.Comment,
+      public?: true,
+      destination_attribute: :post_id
+    )
 
     many_to_many(:tags, AshGraphql.Test.Tag,
       through: AshGraphql.Test.PostTag,


### PR DESCRIPTION
# Contributor checklist

So it turns out that the test I wrote for this was broken, and also it turns out that the previous implementation was broken as well, since the relationship logic hooked into some "default" pagination logic that expects `nil` for no pagination. This fixes the `:none` strategy, and adds some better tests.

Leave anything that you believe does not apply unchecked.

- [X] Bug fixes include regression tests
- [X] Chores
- [X] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
