### PR TITLE
Add failing test for a calculation with a :struct return type

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -748,6 +748,16 @@ defmodule AshGraphql do
         type = Ash.Type.NewType.subtype_of(type)
         nested_attrs(type, all_domains, constraints, already_checked)
 
+      type == Ash.Type.Struct && Keyword.has_key?(constraints, :instance_of) ->
+        type = Keyword.get(constraints, :instance_of)
+
+        if function_exported?(type, :subtype_constraints, 0) do
+          constraints = apply(type, :subtype_constraints, [])
+          nested_attrs(type, all_domains, constraints, already_checked)
+        else
+          {[], already_checked}
+        end
+
       true ->
         {[], already_checked}
     end

--- a/test/read_test.exs
+++ b/test/read_test.exs
@@ -1625,4 +1625,34 @@ defmodule AshGraphql.ReadTest do
              } = result
     end
   end
+
+  describe "calculations" do
+    test "loads calculated struct type that uses constraint" do
+      post =
+        AshGraphql.Test.Post
+        |> Ash.Changeset.for_create(:create,
+          text: "a",
+          published: true
+        )
+        |> Ash.create!()
+
+      resp =
+        """
+        query postLibrary {
+          postLibrary(sort: {field: TEXT}) {
+            structCalc {
+              some
+            }
+          }
+        }
+        """
+        |> Absinthe.run(AshGraphql.Test.Schema)
+
+      assert {:ok, result} = resp
+
+      refute Map.has_key?(result, :errors)
+
+      assert %{data: %{"postLibrary" => [%{"structCalc" => %{"some" => "string"}}]}} = result
+    end
+  end
 end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -625,6 +625,16 @@ defmodule AshGraphql.Test.Post do
       end,
       public?: true
     )
+
+    calculate(
+      :struct_calc,
+      :struct,
+      fn records, _ ->
+        Enum.map(records, fn _ -> %{some: "string"} end)
+      end,
+      public?: true,
+      constraints: [instance_of: AshGraphql.Test.UnreferencedType]
+    )
   end
 
   aggregates do

--- a/test/support/types/unreferenced_type.ex
+++ b/test/support/types/unreferenced_type.ex
@@ -1,0 +1,13 @@
+defmodule AshGraphql.Test.UnreferencedType do
+  @moduledoc false
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        some: [
+          type: :string,
+          allow_nil?: false
+        ]
+      ]
+    ]
+end


### PR DESCRIPTION
Types don't seem to get pulled in when using a `:struct` return type in a calculation with an `instance_of` constraint. I ran into this as a more complicated circumstance (a `calculation -> struct with instance_of constraint (another resource) -> calculation -> union NewType -> array -> struct`), but this might be the core of it!

```
# 1
%{
  errors: [
    %{message: "Field \"structCalc\" must not have a selection since type \"JsonString\" has no subfields.", locations: [%{line: 3, column: 5}]},
    %{message: "Cannot query field \"some\" on type \"JsonString\".", locations: [%{line: 4, column: 7}]}
  ]
}
```