### PR TITLE
[Relay] Add support for relay_id_translation on GraphQL subscriptions

### DIFF
--- a/documentation/dsls/DSL-AshGraphql.Domain.md
+++ b/documentation/dsls/DSL-AshGraphql.Domain.md
@@ -538,6 +538,7 @@ end
 | [`action_types`](#graphql-subscriptions-subscribe-action_types){: #graphql-subscriptions-subscribe-action_types } | `list(atom) \| atom` |  | The type of actions the subsciption should listen to. |
 | [`read_action`](#graphql-subscriptions-subscribe-read_action){: #graphql-subscriptions-subscribe-read_action } | `atom` |  | The read action to use for reading data |
 | [`hide_inputs`](#graphql-subscriptions-subscribe-hide_inputs){: #graphql-subscriptions-subscribe-hide_inputs } | `list(atom)` | `[]` | A list of inputs to hide from the subscription, usable if the read action has arguments. |
+| [`relay_id_translations`](#graphql-subscriptions-subscribe-relay_id_translations){: #graphql-subscriptions-subscribe-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`meta`](#graphql-subscriptions-subscribe-meta){: #graphql-subscriptions-subscribe-meta } | `keyword` |  | A keyword list of metadata to include in the subscription. |
 
 

--- a/documentation/dsls/DSL-AshGraphql.Resource.md
+++ b/documentation/dsls/DSL-AshGraphql.Resource.md
@@ -558,6 +558,7 @@ end
 | [`action_types`](#graphql-subscriptions-subscribe-action_types){: #graphql-subscriptions-subscribe-action_types } | `list(atom) \| atom` |  | The type of actions the subsciption should listen to. |
 | [`read_action`](#graphql-subscriptions-subscribe-read_action){: #graphql-subscriptions-subscribe-read_action } | `atom` |  | The read action to use for reading data |
 | [`hide_inputs`](#graphql-subscriptions-subscribe-hide_inputs){: #graphql-subscriptions-subscribe-hide_inputs } | `list(atom)` | `[]` | A list of inputs to hide from the subscription, usable if the read action has arguments. |
+| [`relay_id_translations`](#graphql-subscriptions-subscribe-relay_id_translations){: #graphql-subscriptions-subscribe-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`meta`](#graphql-subscriptions-subscribe-meta){: #graphql-subscriptions-subscribe-meta } | `keyword` |  | A keyword list of metadata to include in the subscription. |
 
 

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -1306,6 +1306,7 @@ defmodule AshGraphql.Resource do
           action_middleware ++
             domain_middleware(domain) ++
             metadata_middleware(subscription.meta) ++
+            id_translation_middleware(subscription.relay_id_translations, relay_ids?) ++
             [
               {{AshGraphql.Graphql.Resolver, :resolve},
                {domain, resource, subscription, relay_ids?}}

--- a/lib/resource/subscription.ex
+++ b/lib/resource/subscription.ex
@@ -8,6 +8,7 @@ defmodule AshGraphql.Resource.Subscription do
     :read_action,
     :actor,
     :hide_inputs,
+    :relay_id_translations,
     :meta
   ]
 
@@ -38,6 +39,13 @@ defmodule AshGraphql.Resource.Subscription do
       type: {:list, :atom},
       doc:
         "A list of inputs to hide from the subscription, usable if the read action has arguments.",
+      default: []
+    ],
+    relay_id_translations: [
+      type: :keyword_list,
+      doc: """
+      A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more.
+      """,
       default: []
     ],
     meta: [

--- a/test/support/resources/relay_subscribable.ex
+++ b/test/support/resources/relay_subscribable.ex
@@ -12,6 +12,7 @@ defmodule AshGraphql.Test.RelaySubscribable do
     type :relay_subscribable
 
     mutations do
+      update :update_relay_subscribable, :update
       destroy :destroy_subscribable_relay, :destroy
     end
 
@@ -25,6 +26,17 @@ defmodule AshGraphql.Test.RelaySubscribable do
       subscribe(:subscribable_deleted_relay) do
         action_types(:destroy)
       end
+
+      subscribe(:subscribable_events_relay_with_arguments) do
+        read_action(:read_with_arg)
+        actions([:create])
+      end
+
+      subscribe(:subscribable_events_relay_with_id_filter) do
+        read_action(:read_with_id_arg)
+        action_types([:create, :update, :destroy])
+        relay_id_translations(subscribable_id: :relay_subscribable)
+      end
     end
   end
 
@@ -37,7 +49,7 @@ defmodule AshGraphql.Test.RelaySubscribable do
       authorize_if(expr(actor_id == ^actor(:id)))
     end
 
-    policy action([:open_read, :read_with_arg]) do
+    policy action([:open_read, :read_with_arg, :read_with_id_arg]) do
       authorize_if(always())
     end
   end
@@ -64,6 +76,14 @@ defmodule AshGraphql.Test.RelaySubscribable do
       end
 
       filter(expr(topic == ^arg(:topic)))
+    end
+
+    read :read_with_id_arg do
+      argument(:subscribable_id, :uuid) do
+        allow_nil? false
+      end
+
+      filter(expr(id == ^arg(:subscribable_id)))
     end
   end
 


### PR DESCRIPTION
Adds support for passing relay id's to subscription read_actions.

Closes #348 

Fortunately this was pretty straight forward and just required adding the `id_translation_middleware` for when subscriptions are setup and created.

PR also includes a test, which required making some changes to the test relay_schema.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
