### PR TITLE
fix: only resolve notifications for the same tenant

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -552,6 +552,28 @@ defmodule AshGraphql.Graphql.Resolver do
   end
 
   def resolve(
+        %{
+          context: %{tenant: resolution_tenant} = context,
+          root_value: [%{tenant: notifcation_tenant} | _]
+        } =
+          resolution,
+        {domain, resource, %AshGraphql.Resource.Subscription{read_action: read_action}, _}
+      )
+      when resolution_tenant != notifcation_tenant do
+    Absinthe.Resolution.put_result(
+      resolution,
+      {:error,
+       to_errors(
+         [Ash.Error.Query.NotFound.exception()],
+         context,
+         domain,
+         resource,
+         read_action
+       )}
+    )
+  end
+
+  def resolve(
         %{arguments: args, context: context, root_value: notifications} = resolution,
         {domain, resource,
          %AshGraphql.Resource.Subscription{read_action: read_action, name: name}, relay_ids?}

--- a/lib/subscription/batcher.ex
+++ b/lib/subscription/batcher.ex
@@ -34,7 +34,7 @@ defmodule AshGraphql.Subscription.Batcher do
   defmodule Notification do
     @moduledoc false
 
-    defstruct [:action_type, :data]
+    defstruct [:action_type, :data, :tenant]
   end
 
   def start_link(opts \\ []) do

--- a/lib/subscription/notifier.ex
+++ b/lib/subscription/notifier.ex
@@ -17,7 +17,11 @@ defmodule AshGraphql.Subscription.Notifier do
            notification.action.type in List.wrap(subscription.action_types) do
         Absinthe.Subscription.publish(
           pub_sub,
-          %Notification{action_type: notification.action.type, data: notification.data},
+          %Notification{
+            action_type: notification.action.type,
+            data: notification.data,
+            tenant: notification.changeset.tenant
+          },
           [{subscription.name, "*"}]
         )
       end


### PR DESCRIPTION
# Contributor checklist

This should make the test in #351 in pass.

`Ash.can` doesn't add the filter for the tenant, that's why we allowed the data to be passed through. But that would have only worked for create and update, as we don't use that check for destroys. 

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
