### PR TITLE
adds simple warning when falling back to jsonstring

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -4942,7 +4942,26 @@ defmodule AshGraphql.Resource do
         AshGraphql.Resource.Info.type(constraints[:instance_of])
       end
 
-    type || get_specific_field_type(Ash.Type.Map, %{constraints: constraints}, resource, input?)
+    result =
+      type || get_specific_field_type(Ash.Type.Map, %{constraints: constraints}, resource, input?)
+
+    # Warn when struct with instance_of falls back to JsonString for input
+    if input? && constraints[:instance_of] &&
+         Ash.Resource.Info.resource?(constraints[:instance_of]) &&
+         result == (Application.get_env(:ash_graphql, :json_type) || :json_string) do
+      IO.warn("""
+      Struct type with instance_of constraint falls back to JsonString for input. 
+      Consider creating a custom type with `use AshGraphql.Type` and `graphql_input_type/1` 
+      for structured validation.
+
+      Resource: #{inspect(resource)}
+      Target: #{inspect(constraints[:instance_of])}
+
+      See: https://hexdocs.pm/ash_graphql/use-struct-types-with-graphql.html
+      """)
+    end
+
+    result
   end
 
   defp get_specific_field_type(Ash.Type.File, _, _, _), do: :upload


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
