### PR TITLE
fix like/ilike not showing up on string calculations

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -2904,6 +2904,7 @@ defmodule AshGraphql.Resource do
 
       filter_fields =
         Ash.Filter.builtin_operators()
+        |> Enum.concat(Ash.DataLayer.functions(resource))
         |> Enum.filter(& &1.predicate?())
         |> restrict_for_lists(field_type)
         |> Enum.flat_map(


### PR DESCRIPTION
Seems like this was simply a result of not including supported functions when generating the filter inputs.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
