### PR TITLE
clear out managed relationship requirements process variable once it's been used

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -260,9 +260,14 @@ defmodule AshGraphql do
                 Absinthe.Blueprint.add_field(blueprint, "RootSubscriptionType", subscription)
               end)
 
+            managed_relationship_requirements =
+              Process.get(:managed_relationship_requirements, [])
+
+            Process.put(:managed_relationship_requirements, [])
+
             managed_relationship_types =
               AshGraphql.Resource.managed_relationship_definitions(
-                Process.get(:managed_relationship_requirements, []),
+                managed_relationship_requirements,
                 unquote(schema)
               )
               |> Enum.uniq_by(& &1.identifier)


### PR DESCRIPTION
My team has been having some schema instability in certain cases in our codebase. I did some debugging today and it seemed like some managed relationship inputs were somehow getting associated to the wrong domain in certain cases. I'm fairly certain this comes down to the fact that this process variable (which looks very hacky to me 😅 ) is only ever being added to, but never cleared out once it's been processed.

I'm not 100% sure if this fix is correct so I'd appreciate if someone with better familiarity with this code gave this a close review.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
  - [ ] I honestly don't know how to put together a replication of this bug, sorry
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
