### PR TITLE
Adds tracer propagation to enable proper telemetry tracing for GraphQL operations

### DIFF
--- a/documentation/topics/monitoring.md
+++ b/documentation/topics/monitoring.md
@@ -12,7 +12,7 @@ A tracer can be configured in the domain. It will fallback to the global tracer 
 
 ```elixir
 graphql do
-  trace MyApp.Tracer
+  tracer MyApp.Tracer
 end
 ```
 

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -369,7 +369,8 @@ defmodule AshGraphql.Graphql.Resolver do
           |> Ash.Query.for_read(action, %{},
             actor: opts[:actor],
             domain: domain,
-            authorize?: AshGraphql.Domain.Info.authorize?(domain)
+            authorize?: AshGraphql.Domain.Info.authorize?(domain),
+            tracer: AshGraphql.Domain.Info.tracer(domain)
           )
           |> load_fields(
             [
@@ -492,7 +493,8 @@ defmodule AshGraphql.Graphql.Resolver do
                    |> Ash.Query.for_read(action, %{},
                      actor: Map.get(context, :actor),
                      domain: domain,
-                     authorize?: AshGraphql.Domain.Info.authorize?(domain)
+                     authorize?: AshGraphql.Domain.Info.authorize?(domain),
+                     tracer: AshGraphql.Domain.Info.tracer(domain)
                    ),
                  query <-
                    load_fields(

--- a/test/read_test.exs
+++ b/test/read_test.exs
@@ -1629,4 +1629,19 @@ defmodule AshGraphql.ReadTest do
              } = result
     end
   end
+
+  test "domain tracer configuration is correctly retrieved" do
+    # Create a test domain with tracer configuration
+    defmodule TestDomainWithTracer do
+      use Ash.Domain,
+        extensions: [AshGraphql.Domain]
+
+      graphql do
+        tracer MyApp.Tracer
+      end
+    end
+
+    # Verify that the tracer configuration is correctly retrieved
+    assert AshGraphql.Domain.Info.tracer(TestDomainWithTracer) == [MyApp.Tracer]
+  end
 end


### PR DESCRIPTION
   ## Summary
   
   Adds tracer propagation to enable proper telemetry tracing for GraphQL operations.
   
   ## Changes
   
   - Modified `lib/graphql/resolver.ex` to pass domain tracer configuration to `Ash.Query.for_read/4` calls
   - Added `tracer: AshGraphql.Domain.Info.tracer(domain)` parameter to single-record and list resolvers
   
   ## Purpose
   
   Without this change, GraphQL operations do not propagate the configured tracer, preventing telemetry handlers from running.
   
   ## Testing
   
   - All existing tests pass
   - Code quality checks (Credo, Dialyzer) pass
   - No breaking changes to existing functionality