### PR TITLE
Fix filter evaluation for subscriptions

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -660,8 +660,10 @@ defmodule AshGraphql.Graphql.Resolver do
                     {:ok, true, %{authorize_results: []} = query} ->
                       Enum.reduce(data, {[], []}, fn record, {known, refetch} ->
                         case Ash.Expr.eval(query.filter,
-                               record: data,
-                               unknown_on_unknown_refs?: true
+                               record: record,
+                               unknown_on_unknown_refs?: true,
+                               context: context,
+                               resource: resource
                              ) do
                           {:ok, true} ->
                             {[record | known], refetch}

--- a/test/subscription_test.exs
+++ b/test/subscription_test.exs
@@ -36,7 +36,7 @@ defmodule AshGraphql.SubscriptionTest do
   end
 
   @admin %{
-    id: 1,
+    id: Ash.UUID.generate(),
     role: :admin
   }
 
@@ -245,15 +245,15 @@ defmodule AshGraphql.SubscriptionTest do
   end
 
   test "policies are applied to subscriptions" do
-    actor1 = %{
-      id: 1,
-      role: :user
-    }
+    actor1 =
+      AshGraphql.Test.Actor
+      |> Ash.Changeset.for_create(:create, %{role: :user}, actor: @admin)
+      |> Ash.create!()
 
-    actor2 = %{
-      id: 2,
-      role: :user
-    }
+    actor2 =
+      AshGraphql.Test.Actor
+      |> Ash.Changeset.for_create(:create, %{role: :user}, actor: @admin)
+      |> Ash.create!()
 
     assert {:ok, %{"subscribed" => topic1}} =
              Absinthe.run(
@@ -301,7 +301,7 @@ defmodule AshGraphql.SubscriptionTest do
 
     subscribable =
       Subscribable
-      |> Ash.Changeset.for_create(:create, %{text: "foo", actor_id: 1}, actor: @admin)
+      |> Ash.Changeset.for_create(:create, %{text: "foo", actor_id: actor1.id}, actor: @admin)
       |> Ash.create!()
 
     # actor1 will get data because it can see the resource
@@ -315,12 +315,12 @@ defmodule AshGraphql.SubscriptionTest do
 
   test "can dedup with actor fun" do
     actor1 = %{
-      id: 1,
+      id: Ash.UUID.generate(),
       role: :user
     }
 
     actor2 = %{
-      id: 2,
+      id: Ash.UUID.generate(),
       role: :user
     }
 
@@ -358,7 +358,7 @@ defmodule AshGraphql.SubscriptionTest do
 
     subscribable =
       Subscribable
-      |> Ash.Changeset.for_create(:create, %{text: "foo", actor_id: 1}, actor: @admin)
+      |> Ash.Changeset.for_create(:create, %{text: "foo", actor_id: actor1.id}, actor: @admin)
       |> Ash.create!()
 
     assert_receive {^topic1, %{data: subscription_data}}
@@ -369,7 +369,7 @@ defmodule AshGraphql.SubscriptionTest do
 
   test "can subscribe to read actions that take arguments" do
     actor1 = %{
-      id: 1,
+      id: Ash.UUID.generate(),
       role: :user
     }
 
@@ -394,7 +394,7 @@ defmodule AshGraphql.SubscriptionTest do
 
     subscribable =
       Subscribable
-      |> Ash.Changeset.for_create(:create, %{text: "foo", topic: "news", actor_id: 1},
+      |> Ash.Changeset.for_create(:create, %{text: "foo", topic: "news", actor_id: actor1.id},
         actor: @admin
       )
       |> Ash.create!()
@@ -461,10 +461,10 @@ defmodule AshGraphql.SubscriptionTest do
   end
 
   test "can subscribe on the domain" do
-    actor1 = %{
-      id: 1,
-      role: :user
-    }
+    actor1 =
+      AshGraphql.Test.Actor
+      |> Ash.Changeset.for_create(:create, %{role: :user}, actor: @admin)
+      |> Ash.create!()
 
     subscription = """
     subscription {
@@ -486,7 +486,7 @@ defmodule AshGraphql.SubscriptionTest do
 
     subscribable =
       Subscribable
-      |> Ash.Changeset.for_create(:create, %{text: "foo", topic: "news", actor_id: 1},
+      |> Ash.Changeset.for_create(:create, %{text: "foo", topic: "news", actor_id: actor1.id},
         actor: @admin
       )
       |> Ash.create!()
@@ -498,10 +498,10 @@ defmodule AshGraphql.SubscriptionTest do
   end
 
   test "can not see forbidden field" do
-    actor1 = %{
-      id: 1,
-      role: :user
-    }
+    actor1 =
+      AshGraphql.Test.Actor
+      |> Ash.Changeset.for_create(:create, %{role: :user}, actor: @admin)
+      |> Ash.create!()
 
     subscription = """
     subscription {
@@ -523,7 +523,7 @@ defmodule AshGraphql.SubscriptionTest do
              )
 
     Subscribable
-    |> Ash.Changeset.for_create(:create, %{text: "foo", topic: "news", actor_id: 1},
+    |> Ash.Changeset.for_create(:create, %{text: "foo", topic: "news", actor_id: actor1.id},
       actor: @admin
     )
     |> Ash.create!()

--- a/test/support/resources/actor.ex
+++ b/test/support/resources/actor.ex
@@ -25,6 +25,7 @@ defmodule AshGraphql.Test.Actor do
     uuid_primary_key(:id)
 
     attribute(:name, :string, public?: true)
+    attribute(:role, :atom, public?: true)
   end
 
   relationships do

--- a/test/support/resources/subscribable.ex
+++ b/test/support/resources/subscribable.ex
@@ -57,7 +57,7 @@ defmodule AshGraphql.Test.Subscribable do
     end
 
     policy action(:read) do
-      authorize_if(expr(actor_id == ^actor(:id)))
+      authorize_if(relates_to_actor_via([:actor]))
     end
 
     policy action([:open_read, :read_with_arg]) do
@@ -101,8 +101,11 @@ defmodule AshGraphql.Test.Subscribable do
 
     attribute(:text, :string, public?: true)
     attribute(:topic, :string, public?: true)
-    attribute(:actor_id, :integer, public?: true)
     create_timestamp(:created_at)
     update_timestamp(:updated_at)
+  end
+
+  relationships do
+    belongs_to(:actor, AshGraphql.Test.Actor, public?: true)
   end
 end


### PR DESCRIPTION
Pass record, context, and resource to Ash.Expr.eval when evaluating filters. Update tests to create real Actor records (use UUIDs) and reference actor IDs from created records. Replace actor_id attribute with a belongs_to(:actor) relation and change the read policy to use relates_to_actor_via/1 so subscription authorization behaves correctly.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
