### PR TITLE
add error impl for generic action invalid argument

### DIFF
--- a/lib/error.ex
+++ b/lib/error.ex
@@ -80,6 +80,18 @@ defimpl AshGraphql.Error, for: Ash.Error.Query.InvalidArgument do
   end
 end
 
+defimpl AshGraphql.Error, for: Ash.Error.Action.InvalidArgument do
+  def to_error(error) do
+    %{
+      message: error.message,
+      short_message: error.message,
+      code: "invalid_argument",
+      vars: Map.new(error.vars),
+      fields: [error.field]
+    }
+  end
+end
+
 defimpl AshGraphql.Error, for: Ash.Error.Changes.Required do
   def to_error(error) do
     %{


### PR DESCRIPTION
I noticed that invalid arguments to generic actions will cause errors to be thrown. The issue was that there's no impl of `AshGraphql.Error` for those errors.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
