### PR TITLE
Fix compile warnings for optional AshAuthentication dependency

### DIFF
--- a/lib/error.ex
+++ b/lib/error.ex
@@ -184,26 +184,30 @@ defimpl AshGraphql.Error, for: Ash.Error.Invalid.InvalidPrimaryKey do
   end
 end
 
-defimpl AshGraphql.Error, for: AshAuthentication.Errors.AuthenticationFailed do
-  def to_error(_error) do
-    %{
-      message: "Authentication failed",
-      short_message: "Authentication failed",
-      fields: [],
-      code: "authentication_failed",
-      vars: %{}
-    }
+if Code.ensure_loaded?(AshAuthentication.Errors.AuthenticationFailed) do
+  defimpl AshGraphql.Error, for: AshAuthentication.Errors.AuthenticationFailed do
+    def to_error(_error) do
+      %{
+        message: "Authentication failed",
+        short_message: "Authentication failed",
+        fields: [],
+        code: "authentication_failed",
+        vars: %{}
+      }
+    end
   end
 end
 
-defimpl AshGraphql.Error, for: AshAuthentication.Errors.InvalidToken do
-  def to_error(_error) do
-    %{
-      message: "An invalid token was presented",
-      short_message: "Invalid token",
-      fields: [],
-      code: "invalid_token",
-      vars: %{}
-    }
+if Code.ensure_loaded?(AshAuthentication.Errors.InvalidToken) do
+  defimpl AshGraphql.Error, for: AshAuthentication.Errors.InvalidToken do
+    def to_error(_error) do
+      %{
+        message: "An invalid token was presented",
+        short_message: "Invalid token",
+        fields: [],
+        code: "invalid_token",
+        vars: %{}
+      }
+    end
   end
 end


### PR DESCRIPTION
## Summary

Wrap optional AshAuthentication protocol implementations with `Code.ensure_loaded?` to prevent compile warnings when the dependency is not directly required by ash_graphql.

# Contributor checklist

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [X] Refactoring
- [ ] Update dependencies
