### PR TITLE
fix: don't pass select to mutations, fixes notification data

### DIFF
--- a/lib/graphql/errors.ex
+++ b/lib/graphql/errors.ex
@@ -111,8 +111,7 @@ defmodule AshGraphql.Errors do
     {mapped_path, _context} =
       Enum.reduce(all_segments, {[], initial_context}, fn segment, {acc, ctx} ->
         {resolved, next_ctx} = resolve_segment_with_context(segment, ctx)
-        acc = if resolved, do: acc ++ [resolved], else: acc
-        {acc, next_ctx}
+        {acc ++ [resolved], next_ctx}
       end)
 
     # Append field name from error map (resolved with current context).
@@ -364,7 +363,7 @@ defmodule AshGraphql.Errors do
   defp find_argument_type(_, _), do: nil
 
   defp find_attribute_type(name, resource) when is_atom(name) and not is_nil(resource) do
-    attrs = Ash.Resource.Info.attributes(resource) || []
+    attrs = Ash.Resource.Info.attributes(resource)
     attr = Enum.find(attrs, fn a -> Map.get(a, :name) == name end)
     if attr, do: {Map.get(attr, :type), Map.get(attr, :constraints) || []}, else: nil
   rescue

--- a/lib/graphql/errors.ex
+++ b/lib/graphql/errors.ex
@@ -252,7 +252,11 @@ defmodule AshGraphql.Errors do
 
   defp resolve_array_element_segment(segment, context) do
     # Context type is {:array, elem_type}; after index we're "in" element.
-    elem_type = match?({:array, _}, context.type) && elem(context.type, 2)
+    elem_type =
+      case context.type do
+        {:array, inner} -> inner
+        _ -> nil
+      end
     elem_constraints = context.constraints[:items] || context.constraints["items"] || []
     {elem_type, elem_constraints} = unwrap_type(elem_type, elem_constraints)
     inner_context = %{context | type: elem_type, constraints: elem_constraints}

--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -1554,7 +1554,6 @@ defmodule AshGraphql.Graphql.Resolver do
               actor: Map.get(context, :actor),
               authorize?: AshGraphql.Domain.Info.authorize?(domain)
             )
-            |> select_fields(resource, resolution, type_name, ["result"])
             |> load_fields(
               [
                 domain: domain,
@@ -1687,10 +1686,6 @@ defmodule AshGraphql.Graphql.Resolver do
                   read_action: read_action,
                   domain: domain,
                   actor: Map.get(context, :actor),
-                  select:
-                    get_select(resource, resolution, mutation_result_type(mutation_name), [
-                      "result"
-                    ]),
                   load:
                     get_loads(
                       [
@@ -1857,11 +1852,7 @@ defmodule AshGraphql.Graphql.Resolver do
                   context: get_context(context) || %{},
                   authorize?: AshGraphql.Domain.Info.authorize?(domain),
                   actor: Map.get(context, :actor),
-                  domain: domain,
-                  select:
-                    get_select(resource, resolution, mutation_result_type(mutation_name), [
-                      "result"
-                    ])
+                  domain: domain
                 )
                 |> case do
                   %Ash.BulkResult{status: :success, records: [value]} ->

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -1258,5 +1258,34 @@ defmodule AshGraphql.ErrorsTest do
 
       assert [%{code: "forbidden", fields: [], path: ["input", "nested"]}] = errors
     end
+
+    test "path resolves through {:array, :map} argument without crashing" do
+      error =
+        Ash.Error.Changes.InvalidAttribute.exception(
+          field: :text,
+          message: "invalid"
+        )
+        |> Ash.Error.set_path([:comments, 0])
+
+      action = Ash.Resource.Info.action(AshGraphql.Test.Post, :with_comments)
+
+      errors =
+        AshGraphql.Errors.to_errors(
+          [error],
+          %{},
+          AshGraphql.Test.Domain,
+          AshGraphql.Test.Post,
+          action,
+          ["input"]
+        )
+
+      assert [
+               %{
+                 code: "invalid_attribute",
+                 fields: [:text],
+                 path: ["input", "comments", "0", "text"]
+               }
+             ] = errors
+    end
   end
 end

--- a/test/mutation_notification_test.exs
+++ b/test/mutation_notification_test.exs
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.MutationNotificationTest do
+  @moduledoc """
+  Tests that GraphQL mutations don't strip attributes from Ash notification data.
+
+  When a GraphQL mutation requests only a subset of fields (e.g. `{ id }`), the
+  notification data sent to Ash notifiers should still include all `select_by_default`
+  attributes. Previously, AshGraphQL passed a restricted `select` based on the GraphQL
+  query fields, which caused Ash to mask unrequested attributes with `%Ash.NotLoaded{}`.
+  This broke downstream notification consumers (PubSub subscribers, GenServers) that
+  relied on attributes like foreign keys.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshGraphql.Test.PubSub
+  alias AshGraphql.Test.Schema
+
+  @admin %{id: Ash.UUID.generate(), role: :admin}
+
+  defp assert_down(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+
+  setup do
+    Application.put_env(:ash_graphql, :notification_spy_pid, self())
+    Application.put_env(PubSub, :notifier_test_pid, self())
+    {:ok, pubsub} = PubSub.start_link()
+    {:ok, absinthe_sub} = Absinthe.Subscription.start_link(PubSub)
+    start_supervised(AshGraphql.Subscription.Batcher, [])
+
+    on_exit(fn ->
+      Application.delete_env(:ash_graphql, :notification_spy_pid)
+      Process.exit(pubsub, :normal)
+      Process.exit(absinthe_sub, :normal)
+      assert_down(pubsub)
+      assert_down(absinthe_sub)
+
+      try do
+        AshGraphql.TestHelpers.stop_ets()
+      rescue
+        _ -> :ok
+      end
+    end)
+  end
+
+  describe "notification data from mutations includes all default attributes" do
+    test "create mutation notification has belongs_to foreign key loaded" do
+      actor =
+        AshGraphql.Test.Actor
+        |> Ash.Changeset.for_create(:create, %{name: "test_actor"})
+        |> Ash.create!()
+
+      resp =
+        """
+        mutation CreateSubscribable($input: CreateSubscribableInput) {
+          createSubscribable(input: $input) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{"input" => %{"text" => "hello", "actorId" => actor.id}},
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"createSubscribable" => %{"errors" => []}}}} = resp
+
+      assert_receive {:ash_notification, notification}, 1000
+      assert notification.data.actor_id == actor.id
+      refute match?(%Ash.NotLoaded{}, notification.data.text)
+    end
+
+    test "update mutation notification has belongs_to foreign key loaded when not queried" do
+      actor =
+        AshGraphql.Test.Actor
+        |> Ash.Changeset.for_create(:create, %{name: "test_actor"})
+        |> Ash.create!()
+
+      subscribable =
+        AshGraphql.Test.Subscribable
+        |> Ash.Changeset.for_create(:create, %{text: "hello", actor_id: actor.id})
+        |> Ash.create!(authorize?: false)
+
+      # Drain the create notification
+      assert_receive {:ash_notification, _create_notification}, 1000
+
+      # Mutation requests ONLY `id` — does not request actorId or text
+      resp =
+        """
+        mutation UpdateSubscribable($id: ID!, $input: UpdateSubscribableInput) {
+          updateSubscribable(id: $id, input: $input) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => subscribable.id,
+            "input" => %{"text" => "updated"}
+          },
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"updateSubscribable" => %{"errors" => []}}}} = resp
+
+      # Notification data should have ALL select_by_default attributes loaded,
+      # not just the ones requested in the GraphQL response
+      assert_receive {:ash_notification, notification}, 1000
+      assert notification.data.actor_id == actor.id
+      assert notification.data.text == "updated"
+      refute match?(%Ash.NotLoaded{}, notification.data.actor_id)
+    end
+
+    test "update mutation response only includes queried fields" do
+      subscribable =
+        AshGraphql.Test.Subscribable
+        |> Ash.Changeset.for_create(:create, %{text: "hello"})
+        |> Ash.create!(authorize?: false)
+
+      resp =
+        """
+        mutation UpdateSubscribable($id: ID!, $input: UpdateSubscribableInput) {
+          updateSubscribable(id: $id, input: $input) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => subscribable.id,
+            "input" => %{"text" => "updated"}
+          },
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"updateSubscribable" => %{"errors" => [], "result" => result}}}} =
+               resp
+
+      # Response should only contain the queried field
+      assert Map.keys(result) == ["id"]
+    end
+
+    test "destroy mutation notification has attributes loaded" do
+      actor =
+        AshGraphql.Test.Actor
+        |> Ash.Changeset.for_create(:create, %{name: "test_actor"})
+        |> Ash.create!()
+
+      subscribable =
+        AshGraphql.Test.Subscribable
+        |> Ash.Changeset.for_create(:create, %{text: "hello", actor_id: actor.id})
+        |> Ash.create!(authorize?: false)
+
+      resp =
+        """
+        mutation DestroySubscribable($id: ID!) {
+          destroySubscribable(id: $id) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{"id" => subscribable.id},
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"destroySubscribable" => %{"errors" => []}}}} = resp
+
+      assert_receive {:ash_notification, notification}, 1000
+      assert notification.data.actor_id == actor.id
+      refute match?(%Ash.NotLoaded{}, notification.data.text)
+    end
+  end
+end

--- a/test/support/notification_spy.ex
+++ b/test/support/notification_spy.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.NotificationSpy do
+  @moduledoc """
+  Test notifier that captures raw Ash notifications for assertion.
+  """
+  use Ash.Notifier
+
+  @impl true
+  def notify(notification) do
+    if pid = Application.get_env(:ash_graphql, :notification_spy_pid) do
+      send(pid, {:ash_notification, notification})
+    end
+
+    :ok
+  end
+end

--- a/test/support/resources/subscribable.ex
+++ b/test/support/resources/subscribable.ex
@@ -8,6 +8,7 @@ defmodule AshGraphql.Test.Subscribable do
     domain: AshGraphql.Test.Domain,
     data_layer: Ash.DataLayer.Ets,
     authorizers: [Ash.Policy.Authorizer],
+    notifiers: [AshGraphql.Test.NotificationSpy],
     extensions: [AshGraphql.Resource]
 
   require Ash.Query


### PR DESCRIPTION
## Problem

AshGraphQL passes select: get_select to create/update/destroy mutations, restricting the Ash operation to only the fields the GraphQL client requested. Since Ash v3.4.8's action_select system, this masks all
unrequested attributes with %Ash.NotLoaded{} — including on notification data sent to Ash notifiers.

This means any mutation like:

```elixir
mutation { deliverParcel(id: "...") { result { id status } } }
```

produces notifications where order_id, company_id, and other foreign keys are Ash.NotLoaded, crashing downstream PubSub subscribers and GenServers that rely on those fields.

The issue became more visible after ash-project/ash#2544 (manage_relationship returning {:not_atomic}), which forces more actions through the non-atomic bulk path where the masking is applied more aggressively.

## Fix

Remove the select option from all three mutation paths (create, update, destroy). Ash defaults to loading all select_by_default attributes, which is what notifiers need. Absinthe already filters the GraphQL response to only
  the requested fields.

## Test plan

- Added NotificationSpy test notifier that captures raw Ash notifications
- Tests verify that belongs_to foreign keys are loaded in notification data even when the GraphQL query only requests id
- Verified the update test fails without the fix (actor_id becomes Ash.NotLoaded)
- Full test suite passes (293 tests, 0 failures)

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
