### PR TITLE
fix: scope AshTypes module to schema for multi-schema support

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -199,7 +199,7 @@ defmodule AshGraphql do
       end
 
       for {domain, resources, first?} <- domains do
-        defmodule Module.concat(domain, AshTypes) do
+        defmodule Module.concat([__MODULE__, domain, AshTypes]) do
           @moduledoc false
           alias Absinthe.{Blueprint, Phase, Pipeline}
 
@@ -386,7 +386,7 @@ defmodule AshGraphql do
           Code.eval_quoted(auto_import_types, [], __ENV__)
         end
 
-        @pipeline_modifier Module.concat(domain, AshTypes)
+        @pipeline_modifier Module.concat([__MODULE__, domain, AshTypes])
       end
     end
   end

--- a/test/multi_schema_test.exs
+++ b/test/multi_schema_test.exs
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 ash_graphql contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.MultiSchemaTest do
+  @moduledoc """
+  Tests that the same domain can be registered in multiple Absinthe schemas
+  without module conflicts or missing builtin types.
+  """
+  use ExUnit.Case, async: false
+
+  # Two schemas sharing AshGraphql.Test.Domain — this should compile
+  # without "cannot define module" errors or missing type errors.
+
+  test "same domain in multiple schemas compiles without conflict" do
+    # If we got here, both schemas compiled successfully.
+    # AshGraphql.Test.Schema and AshGraphql.Test.MultiSchema.SchemaB
+    # both include AshGraphql.Test.Domain.
+    assert Code.ensure_loaded?(AshGraphql.Test.Schema)
+    assert Code.ensure_loaded?(AshGraphql.Test.MultiSchema.SchemaB)
+  end
+
+  test "each schema has its own AshTypes module" do
+    # Schema A's AshTypes (OtherDomain is in the primary schema's domain list)
+    schema_a_types = Module.concat([AshGraphql.Test.Schema, AshGraphql.Test.OtherDomain, AshTypes])
+    assert Code.ensure_loaded?(schema_a_types)
+
+    # Schema B's AshTypes
+    schema_b_types = Module.concat([AshGraphql.Test.MultiSchema.SchemaB, AshGraphql.Test.OtherDomain, AshTypes])
+    assert Code.ensure_loaded?(schema_b_types)
+
+    # They should be different modules
+    assert schema_a_types != schema_b_types
+  end
+
+  test "SchemaB can execute a basic query" do
+    # SchemaB should have builtin types (mutation_error, sort_order, page_info)
+    # and be able to execute queries against shared domain resources
+    assert {:ok, %{data: %{"__typename" => "RootQueryType"}}} =
+             Absinthe.run("{ __typename }", AshGraphql.Test.MultiSchema.SchemaB)
+  end
+end

--- a/test/support/multi_schema.ex
+++ b/test/support/multi_schema.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 ash_graphql contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.MultiSchema do
+  @moduledoc """
+  A second Absinthe schema that shares AshGraphql.Test.Domain with the
+  primary AshGraphql.Test.Schema. Used to verify that the same domain
+  can appear in multiple schemas without module conflicts.
+  """
+
+  defmodule SchemaB do
+    @moduledoc false
+
+    use Absinthe.Schema
+
+    # Intentionally registers the same domain as AshGraphql.Test.Schema
+    # Using OtherDomain which is also registered in the primary schema
+    use AshGraphql, domains: [AshGraphql.Test.OtherDomain]
+
+    query do
+    end
+
+    mutation do
+    end
+  end
+end


### PR DESCRIPTION
## Summary

When the same Ash domain is registered in multiple Absinthe schemas (e.g., splitting a large app into Sales/Purchasing/Finance endpoints with shared domains for cross-domain `belongs_to` references), `Module.concat(domain, AshTypes)` generates the same module name regardless of which schema is compiling, causing module redefinition conflicts.

This changes the module name to `Module.concat([__MODULE__, domain, AshTypes])` as suggested in #422, scoping each generated module to its parent schema.

This also fixes the `first?` / builtin types issue (#422 issue 2) as a side effect: the root cause was that the module conflict caused the second schema to skip the entire `for` loop body, preventing `first?` from working. With per-schema modules, each schema's `for` loop executes fully, and `first?` (already per-schema via `List.update_at(0, ...)`) works correctly.

## Changes

- `defmodule Module.concat(domain, AshTypes)` → `defmodule Module.concat([__MODULE__, domain, AshTypes])`
- `@pipeline_modifier Module.concat(domain, AshTypes)` → `@pipeline_modifier Module.concat([__MODULE__, domain, AshTypes])`

## Test plan

- All 359 existing tests pass
- Verified with a production app using ~20 subdomain schemas with shared domains — compiles without conflicts

Closes #422