### PR TITLE
fix: per-schema AshTypes + structural type dedup for multi-schema support

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -199,7 +199,7 @@ defmodule AshGraphql do
       end
 
       for {domain, resources, first?} <- domains do
-        defmodule Module.concat(domain, AshTypes) do
+        defmodule Module.concat([__MODULE__, domain, AshTypes]) do
           @moduledoc false
           alias Absinthe.{Blueprint, Phase, Pipeline}
 
@@ -386,7 +386,7 @@ defmodule AshGraphql do
           Code.eval_quoted(auto_import_types, [], __ENV__)
         end
 
-        @pipeline_modifier Module.concat(domain, AshTypes)
+        @pipeline_modifier Module.concat([__MODULE__, domain, AshTypes])
       end
     end
   end

--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -370,11 +370,21 @@ defmodule AshGraphql do
 
             new_defs =
               List.update_at(blueprint_with_subscriptions.schema_definitions, 0, fn schema_def ->
+                # Deduplicate only structurally identical types — if two types
+                # share an identifier but differ in structure, let Absinthe's
+                # TypeNamesAreUnique phase report the conflict.
+                new_types =
+                  (type_definitions ++ managed_relationship_types)
+                  |> Enum.reject(fn type ->
+                    Enum.any?(schema_def.type_definitions, fn existing ->
+                      existing.identifier == type.identifier and existing == type
+                    end)
+                  end)
+
                 %{
                   schema_def
                   | type_definitions:
-                      schema_def.type_definitions ++
-                        type_definitions ++ managed_relationship_types
+                      schema_def.type_definitions ++ new_types
                 }
               end)
 

--- a/test/multi_schema_test.exs
+++ b/test/multi_schema_test.exs
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 ash_graphql contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.MultiSchemaTest do
+  @moduledoc """
+  Tests that the same domain can be registered in multiple Absinthe schemas
+  without module conflicts or missing builtin types.
+  """
+  use ExUnit.Case, async: false
+
+  # Two schemas sharing AshGraphql.Test.Domain — this should compile
+  # without "cannot define module" errors or missing type errors.
+
+  test "same domain in multiple schemas compiles without conflict" do
+    # If we got here, both schemas compiled successfully.
+    # AshGraphql.Test.Schema and AshGraphql.Test.MultiSchema.SchemaB
+    # both include AshGraphql.Test.Domain.
+    assert Code.ensure_loaded?(AshGraphql.Test.Schema)
+    assert Code.ensure_loaded?(AshGraphql.Test.MultiSchema.SchemaB)
+  end
+
+  test "each schema has its own AshTypes module" do
+    # Schema A's AshTypes (OtherDomain is in the primary schema's domain list)
+    schema_a_types = Module.concat([AshGraphql.Test.Schema, AshGraphql.Test.OtherDomain, AshTypes])
+    assert Code.ensure_loaded?(schema_a_types)
+
+    # Schema B's AshTypes
+    schema_b_types = Module.concat([AshGraphql.Test.MultiSchema.SchemaB, AshGraphql.Test.OtherDomain, AshTypes])
+    assert Code.ensure_loaded?(schema_b_types)
+
+    # They should be different modules
+    assert schema_a_types != schema_b_types
+  end
+
+  test "SchemaB can execute a basic query" do
+    # SchemaB should have builtin types (mutation_error, sort_order, page_info)
+    # and be able to execute queries against shared domain resources
+    assert {:ok, %{data: %{"__typename" => "RootQueryType"}}} =
+             Absinthe.run("{ __typename }", AshGraphql.Test.MultiSchema.SchemaB)
+  end
+end

--- a/test/support/multi_schema.ex
+++ b/test/support/multi_schema.ex
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 ash_graphql contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.MultiSchema do
+  @moduledoc """
+  A second Absinthe schema that shares AshGraphql.Test.Domain with the
+  primary AshGraphql.Test.Schema. Used to verify that the same domain
+  can appear in multiple schemas without module conflicts.
+  """
+
+  defmodule SchemaB do
+    @moduledoc false
+
+    use Absinthe.Schema
+
+    # Intentionally registers the same domain as AshGraphql.Test.Schema
+    # Using OtherDomain which is also registered in the primary schema
+    use AshGraphql, domains: [AshGraphql.Test.OtherDomain]
+
+    query do
+    end
+
+    mutation do
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This is an alternative to #424 that includes both fixes for #422:

1. **Per-schema AshTypes module** (same as #424): `Module.concat([__MODULE__, domain, AshTypes])` scopes each generated module to its parent schema, preventing module redefinition conflicts when the same domain appears in multiple schemas.

2. **Structural type deduplication**: When appending `type_definitions` to the blueprint, reject types only when an existing type has the same identifier AND is structurally equal (`existing == type`). Types with the same name but different structure are left for Absinthe's `TypeNamesAreUnique` phase to diagnose.

This addresses both points from #422. The dedup approach follows your suggestion of checking "100% exactly equal" rather than just identifier matching.

## Changes

- `Module.concat(domain, AshTypes)` → `Module.concat([__MODULE__, domain, AshTypes])` (2 locations)
- `type_definitions` append: reject structurally identical duplicates before appending

## Test plan

- All 359 existing tests pass
- Verified with a production app using ~20 subdomain schemas with shared domains

See #424 for the minimal version (without dedup) if you prefer a smaller change.

Related: #422