### PR TITLE
fix: deduplicate structurally identical types in blueprint

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -377,7 +377,7 @@ defmodule AshGraphql do
                   (type_definitions ++ managed_relationship_types)
                   |> Enum.reject(fn type ->
                     Enum.any?(schema_def.type_definitions, fn existing ->
-                      existing.identifier == type.identifier and existing == type
+                      existing == type
                     end)
                   end)
 

--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -370,11 +370,21 @@ defmodule AshGraphql do
 
             new_defs =
               List.update_at(blueprint_with_subscriptions.schema_definitions, 0, fn schema_def ->
+                # Deduplicate only structurally identical types — if two types
+                # share an identifier but differ in structure, let Absinthe's
+                # TypeNamesAreUnique phase report the conflict.
+                new_types =
+                  (type_definitions ++ managed_relationship_types)
+                  |> Enum.reject(fn type ->
+                    Enum.any?(schema_def.type_definitions, fn existing ->
+                      existing.identifier == type.identifier and existing == type
+                    end)
+                  end)
+
                 %{
                   schema_def
                   | type_definitions:
-                      schema_def.type_definitions ++
-                        type_definitions ++ managed_relationship_types
+                      schema_def.type_definitions ++ new_types
                 }
               end)
 


### PR DESCRIPTION
## Summary

When types are pre-loaded via `import_types` and AshGraphql also injects them (e.g., builtin types like `mutation_error`, `sort_order`, `page_info`), the same type can appear twice in the blueprint, causing Absinthe's `TypeNamesAreUnique` phase to report conflicts.

This adds a dedup step before appending `type_definitions` to the blueprint: types are rejected only when an existing type has the same identifier **and** is structurally equal (`existing == type`). Types with the same name but different structure are left for Absinthe to diagnose — preserving the existing error reporting behavior.

This is independent of #424 (per-schema AshTypes scoping). Each PR addresses a different aspect of #422 and can be merged independently.

## Changes

- `type_definitions ++ managed_relationship_types` append now filters out structurally identical duplicates

## Test plan

- All 359 existing tests pass

Related: #422