### PR TITLE
fix: use pattern matching in resolve_array_element_segment

### DIFF
--- a/lib/graphql/errors.ex
+++ b/lib/graphql/errors.ex
@@ -253,7 +253,11 @@ defmodule AshGraphql.Errors do
 
   defp resolve_array_element_segment(segment, context) do
     # Context type is {:array, elem_type}; after index we're "in" element.
-    elem_type = match?({:array, _}, context.type) && elem(context.type, 2)
+    elem_type =
+      case context.type do
+        {:array, inner} -> inner
+        _ -> nil
+      end
     elem_constraints = context.constraints[:items] || context.constraints["items"] || []
     {elem_type, elem_constraints} = unwrap_type(elem_type, elem_constraints)
     inner_context = %{context | type: elem_type, constraints: elem_constraints}

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -1258,5 +1258,34 @@ defmodule AshGraphql.ErrorsTest do
 
       assert [%{code: "forbidden", fields: [], path: ["input", "nested"]}] = errors
     end
+
+    test "path resolves through {:array, :map} argument without crashing" do
+      error =
+        Ash.Error.Changes.InvalidAttribute.exception(
+          field: :text,
+          message: "invalid"
+        )
+        |> Ash.Error.set_path([:comments, 0])
+
+      action = Ash.Resource.Info.action(AshGraphql.Test.Post, :with_comments)
+
+      errors =
+        AshGraphql.Errors.to_errors(
+          [error],
+          %{},
+          AshGraphql.Test.Domain,
+          AshGraphql.Test.Post,
+          action,
+          ["input"]
+        )
+
+      assert [
+               %{
+                 code: "invalid_attribute",
+                 fields: [:text],
+                 path: ["input", "comments", "0", "text"]
+               }
+             ] = errors
+    end
   end
 end


### PR DESCRIPTION
Obviously generated PR message, but I've been running these fixes for weeks/months in prod

## Summary

`AshGraphql.Errors.resolve_array_element_segment/2` calls `elem(context.type, 2)` on what is a 2-tuple `{:array, inner_type}`. Index `2` is out of range for a 2-tuple, so `elem/2` raises `ArgumentError` whenever the error formatter walks a path that crosses an array argument (e.g. `[:comments, 0, :text]`).

The result in production is that the GraphQL error formatter itself crashes mid-formatting, and the underlying business error never reaches the client — the user just sees a 500.

This PR replaces the `elem/2` call with a pattern match that extracts the inner type safely, and adds a regression test that exercises the path through a `{:array, :map}` argument.