### PR TITLE
fix: don't pass select to mutations, fixes notification data

### DIFF
--- a/lib/graphql/resolver.ex
+++ b/lib/graphql/resolver.ex
@@ -1560,7 +1560,6 @@ defmodule AshGraphql.Graphql.Resolver do
               actor: Map.get(context, :actor),
               authorize?: AshGraphql.Domain.Info.authorize?(domain)
             )
-            |> select_fields(resource, resolution, type_name, ["result"])
             |> load_fields(
               [
                 domain: domain,
@@ -1693,10 +1692,6 @@ defmodule AshGraphql.Graphql.Resolver do
                   read_action: read_action,
                   domain: domain,
                   actor: Map.get(context, :actor),
-                  select:
-                    get_select(resource, resolution, mutation_result_type(mutation_name), [
-                      "result"
-                    ]),
                   load:
                     get_loads(
                       [
@@ -1863,11 +1858,7 @@ defmodule AshGraphql.Graphql.Resolver do
                   context: get_context(context) || %{},
                   authorize?: AshGraphql.Domain.Info.authorize?(domain),
                   actor: Map.get(context, :actor),
-                  domain: domain,
-                  select:
-                    get_select(resource, resolution, mutation_result_type(mutation_name), [
-                      "result"
-                    ])
+                  domain: domain
                 )
                 |> case do
                   %Ash.BulkResult{status: :success, records: [value]} ->

--- a/test/mutation_notification_test.exs
+++ b/test/mutation_notification_test.exs
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.MutationNotificationTest do
+  @moduledoc """
+  Tests that GraphQL mutations don't strip attributes from Ash notification data.
+
+  When a GraphQL mutation requests only a subset of fields (e.g. `{ id }`), the
+  notification data sent to Ash notifiers should still include all `select_by_default`
+  attributes. Previously, AshGraphQL passed a restricted `select` based on the GraphQL
+  query fields, which caused Ash to mask unrequested attributes with `%Ash.NotLoaded{}`.
+  This broke downstream notification consumers (PubSub subscribers, GenServers) that
+  relied on attributes like foreign keys.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshGraphql.Test.PubSub
+  alias AshGraphql.Test.Schema
+
+  @admin %{id: Ash.UUID.generate(), role: :admin}
+
+  defp assert_down(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, _, _, _}
+  end
+
+  setup do
+    Application.put_env(:ash_graphql, :notification_spy_pid, self())
+    Application.put_env(PubSub, :notifier_test_pid, self())
+    {:ok, pubsub} = PubSub.start_link()
+    {:ok, absinthe_sub} = Absinthe.Subscription.start_link(PubSub)
+    start_supervised(AshGraphql.Subscription.Batcher, [])
+
+    on_exit(fn ->
+      Application.delete_env(:ash_graphql, :notification_spy_pid)
+      Process.exit(pubsub, :normal)
+      Process.exit(absinthe_sub, :normal)
+      assert_down(pubsub)
+      assert_down(absinthe_sub)
+
+      try do
+        AshGraphql.TestHelpers.stop_ets()
+      rescue
+        _ -> :ok
+      end
+    end)
+  end
+
+  describe "notification data from mutations includes all default attributes" do
+    test "create mutation notification has belongs_to foreign key loaded" do
+      actor =
+        AshGraphql.Test.Actor
+        |> Ash.Changeset.for_create(:create, %{name: "test_actor"})
+        |> Ash.create!()
+
+      resp =
+        """
+        mutation CreateSubscribable($input: CreateSubscribableInput) {
+          createSubscribable(input: $input) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{"input" => %{"text" => "hello", "actorId" => actor.id}},
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"createSubscribable" => %{"errors" => []}}}} = resp
+
+      assert_receive {:ash_notification, notification}, 1000
+      assert notification.data.actor_id == actor.id
+      refute match?(%Ash.NotLoaded{}, notification.data.text)
+    end
+
+    test "update mutation notification has belongs_to foreign key loaded when not queried" do
+      actor =
+        AshGraphql.Test.Actor
+        |> Ash.Changeset.for_create(:create, %{name: "test_actor"})
+        |> Ash.create!()
+
+      subscribable =
+        AshGraphql.Test.Subscribable
+        |> Ash.Changeset.for_create(:create, %{text: "hello", actor_id: actor.id})
+        |> Ash.create!(authorize?: false)
+
+      # Drain the create notification
+      assert_receive {:ash_notification, _create_notification}, 1000
+
+      # Mutation requests ONLY `id` — does not request actorId or text
+      resp =
+        """
+        mutation UpdateSubscribable($id: ID!, $input: UpdateSubscribableInput) {
+          updateSubscribable(id: $id, input: $input) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => subscribable.id,
+            "input" => %{"text" => "updated"}
+          },
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"updateSubscribable" => %{"errors" => []}}}} = resp
+
+      # Notification data should have ALL select_by_default attributes loaded,
+      # not just the ones requested in the GraphQL response
+      assert_receive {:ash_notification, notification}, 1000
+      assert notification.data.actor_id == actor.id
+      assert notification.data.text == "updated"
+      refute match?(%Ash.NotLoaded{}, notification.data.actor_id)
+    end
+
+    test "update mutation response only includes queried fields" do
+      subscribable =
+        AshGraphql.Test.Subscribable
+        |> Ash.Changeset.for_create(:create, %{text: "hello"})
+        |> Ash.create!(authorize?: false)
+
+      resp =
+        """
+        mutation UpdateSubscribable($id: ID!, $input: UpdateSubscribableInput) {
+          updateSubscribable(id: $id, input: $input) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{
+            "id" => subscribable.id,
+            "input" => %{"text" => "updated"}
+          },
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"updateSubscribable" => %{"errors" => [], "result" => result}}}} =
+               resp
+
+      # Response should only contain the queried field
+      assert Map.keys(result) == ["id"]
+    end
+
+    test "destroy mutation notification has attributes loaded" do
+      actor =
+        AshGraphql.Test.Actor
+        |> Ash.Changeset.for_create(:create, %{name: "test_actor"})
+        |> Ash.create!()
+
+      subscribable =
+        AshGraphql.Test.Subscribable
+        |> Ash.Changeset.for_create(:create, %{text: "hello", actor_id: actor.id})
+        |> Ash.create!(authorize?: false)
+
+      resp =
+        """
+        mutation DestroySubscribable($id: ID!) {
+          destroySubscribable(id: $id) {
+            result { id }
+            errors { message }
+          }
+        }
+        """
+        |> Absinthe.run(Schema,
+          variables: %{"id" => subscribable.id},
+          context: %{actor: @admin}
+        )
+
+      assert {:ok, %{data: %{"destroySubscribable" => %{"errors" => []}}}} = resp
+
+      assert_receive {:ash_notification, notification}, 1000
+      assert notification.data.actor_id == actor.id
+      refute match?(%Ash.NotLoaded{}, notification.data.text)
+    end
+  end
+end

--- a/test/support/notification_spy.ex
+++ b/test/support/notification_spy.ex
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.NotificationSpy do
+  @moduledoc """
+  Test notifier that captures raw Ash notifications for assertion.
+  """
+  use Ash.Notifier
+
+  @impl true
+  def notify(notification) do
+    if pid = Application.get_env(:ash_graphql, :notification_spy_pid) do
+      send(pid, {:ash_notification, notification})
+    end
+
+    :ok
+  end
+end

--- a/test/support/resources/subscribable.ex
+++ b/test/support/resources/subscribable.ex
@@ -8,6 +8,7 @@ defmodule AshGraphql.Test.Subscribable do
     domain: AshGraphql.Test.Domain,
     data_layer: Ash.DataLayer.Ets,
     authorizers: [Ash.Policy.Authorizer],
+    notifiers: [AshGraphql.Test.NotificationSpy],
     extensions: [AshGraphql.Resource]
 
   require Ash.Query


### PR DESCRIPTION
Obviously generated PR message, but I've been running these fixes for weeks/months in prod

## Summary

AshGraphQL currently passes `select: get_select(...)` to create/update/destroy mutations, derived from the fields requested in the GraphQL query. Ash's `action_select` system then masks all unrequested attributes with `%Ash.NotLoaded{}` on the result — **including the result handed to notifiers**.

Downstream consumers (PubSub subscribers, custom `Ash.Notifier` modules, GenServers) that read attributes such as foreign keys from `belongs_to` relationships then crash, because those fields are `%Ash.NotLoaded{}`. From the caller's perspective the mutation succeeded, but every notifier downstream blows up.

This PR removes the `select` option from the create, update, and destroy mutation paths in `lib/graphql/resolver.ex`. Ash defaults to loading all `select_by_default?: true` attributes, which is what notifiers expect. Absinthe still filters the GraphQL response to only the fields the client requested, so this is transparent to clients.

## Tests

- New `test/mutation_notification_test.exs` verifies that a notifier receives a fully-loaded record after each of `create`, `update`, and `destroy` mutations, even when the GraphQL query only selects a single field.
- New `test/support/notification_spy.ex` is a minimal notifier used by that test.

## Trade-offs / discussion

This changes the default attribute load behaviour for mutations. Specifically: mutations will now load all `select_by_default?: true` attributes on the result row regardless of what the client requested. For most resources this is the same set that's already loaded by reads, so the practical cost is small, but it is technically a behaviour change.

An alternative would be to keep `select` for the response and separately load all attributes before notifiers run — happy to take that direction instead if maintainers prefer to preserve the current default.