### PR TITLE
Surface aggregate field DSL errors instead of crashing

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -1245,7 +1245,9 @@ defmodule AshGraphql.Resource do
       ) do
     resource
     |> queries(all_domains)
-    |> Enum.filter(&(Map.get(&1, :as_mutation?, false) == as_mutations? and Map.get(&1, :group) == nil))
+    |> Enum.filter(
+      &(Map.get(&1, :as_mutation?, false) == as_mutations? and Map.get(&1, :group) == nil)
+    )
     |> Enum.map(
       &query_field_definition(
         resource,
@@ -3573,6 +3575,14 @@ defmodule AshGraphql.Resource do
            attr when not is_nil(attr) <- Ash.Resource.Info.field(related, aggregate.field) do
         attr
       end
+
+    if aggregate.field && is_nil(attribute) do
+      raise Spark.Error.DslError,
+        module: resource,
+        path: [:aggregates, aggregate.name],
+        message:
+          "All aggregate fields must be attributes or calculations. Got: #{inspect(aggregate.field)}"
+    end
 
     field_type =
       if attribute do

--- a/test/missing_related_domain_test.exs
+++ b/test/missing_related_domain_test.exs
@@ -12,13 +12,13 @@ defmodule AshGraphql.MissingRelatedDomainTest do
   # The test scenario is: both domains are valid, but the schema only registers SourceDomain.
 
   alias AshGraphql.MissingRelatedDomainTest.{
+    AggregateTypoChild,
+    AggregateTypoDomain,
+    AggregateTypoParent,
     RelatedDomain,
     RelatedResource,
     SourceDomain,
-    SourceResource,
-    AggregateTypoChild,
-    AggregateTypoParent,
-    AggregateTypoDomain
+    SourceResource
   }
 
   defmodule RelatedResource do

--- a/test/missing_related_domain_test.exs
+++ b/test/missing_related_domain_test.exs
@@ -5,6 +5,8 @@
 defmodule AshGraphql.MissingRelatedDomainTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   # Define RelatedResource, RelatedDomain, SourceResource, and SourceDomain as valid,
   # fully-compiled modules outside of the test.
   # The test scenario is: both domains are valid, but the schema only registers SourceDomain.
@@ -13,7 +15,10 @@ defmodule AshGraphql.MissingRelatedDomainTest do
     RelatedDomain,
     RelatedResource,
     SourceDomain,
-    SourceResource
+    SourceResource,
+    AggregateTypoChild,
+    AggregateTypoParent,
+    AggregateTypoDomain
   }
 
   defmodule RelatedResource do
@@ -78,6 +83,78 @@ defmodule AshGraphql.MissingRelatedDomainTest do
     end
   end
 
+  defmodule AggregateTypoChild do
+    use Ash.Resource,
+      domain: AggregateTypoDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshGraphql.Resource]
+
+    graphql do
+      type :agg_typo_child
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:read])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+      attribute(:parent_id, :uuid, public?: true)
+      create_timestamp(:created_at, public?: true)
+    end
+
+    calculations do
+      calculate :timestamp, :utc_datetime_usec, expr(created_at) do
+        public?(true)
+      end
+    end
+  end
+
+  defmodule AggregateTypoParent do
+    use Ash.Resource,
+      domain: AggregateTypoDomain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshGraphql.Resource]
+
+    graphql do
+      type :agg_typo_parent
+
+      queries do
+        list :list_parents, :read
+      end
+    end
+
+    actions do
+      default_accept(:*)
+      defaults([:read])
+    end
+
+    attributes do
+      uuid_primary_key(:id)
+    end
+
+    relationships do
+      has_many :children, AggregateTypoChild do
+        public?(true)
+        destination_attribute(:parent_id)
+      end
+    end
+
+    aggregates do
+      max(:latest_child_at, [:children], :time_stamp, public?: true)
+    end
+  end
+
+  defmodule AggregateTypoDomain do
+    use Ash.Domain, extensions: [AshGraphql.Domain]
+
+    resources do
+      resource(AggregateTypoParent)
+      resource(AggregateTypoChild)
+    end
+  end
+
   test "raises at compile time when a related resource's domain is not in the schema" do
     assert_raise RuntimeError, ~r/RelatedDomain/, fn ->
       defmodule TestSchemaMissingDomain do
@@ -88,5 +165,16 @@ defmodule AshGraphql.MissingRelatedDomainTest do
         use AshGraphql, domains: @domains
       end
     end
+  end
+
+  test "typoed aggregate field raises a helpful DSL error" do
+    capture_io(:stderr, fn ->
+      assert_raise Spark.Error.DslError, ~r/:time_stamp/, fn ->
+        defmodule TestSchemaAggregateFieldTypo do
+          use Absinthe.Schema
+          use AshGraphql, domains: [AggregateTypoDomain]
+        end
+      end
+    end)
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
## Summary

I reproduced this issue locally using the example branches from the issue. The plain Ash version showed the correct error, but the AshGraphQL version crashed with `nil.embedded?/0`. I traced the issue to `filterable?/2`, where the aggregate field lookup was returning `nil` and continuing through the pipeline. I added a fix to raise the proper DSL error instead, added a regression test for the `:time_stamp` typo case, and confirmed the full test suite is passing locally (`367 tests, 0 failures`).