### PR TITLE
Fix: Issue 223 - improve embedded input warning

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5351,7 +5351,7 @@ defmodule AshGraphql.Resource do
               nil ->
                 if Keyword.get(opts, :warn_unknown?, true) do
                   IO.warn(
-                    "Embedded type #{inspect(type)} does not have an input type defined, but is accepted as input in at least one location."
+                    "Embedded type #{inspect(type)} cannot define a GraphQL input type because no input fields were produced for its create/update actions (check accept lists, writable? and public? on attributes, and public action arguments). It is still referenced as GraphQL input somewhere; falling back to Application.get_env(:ash_graphql, :json_type) || :json_string."
                   )
                 end
 

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -4,6 +4,7 @@
 
 defmodule AshGraphql.ResourceTest do
   use ExUnit.Case
+  import ExUnit.CaptureIO
 
   test "object generated according to generate_object?" do
     assert %Absinthe.Type.Object{
@@ -395,5 +396,27 @@ defmodule AshGraphql.ResourceTest do
     assert typed_struct_result["name"] == "John Doe"
     assert typed_struct_result["age"] == 30
     assert typed_struct_result["email"] == "john.doe@example.com"
+  end
+
+  test "warns when embedded type produces no GraphQL input fields" do
+    attribute =
+      Ash.Resource.Info.attribute(AshGraphql.Test.ResourceWithEmptyInputEmbed, :empty_value)
+
+    stderr =
+      capture_io(:stderr, fn ->
+        _ =
+          AshGraphql.Resource.field_type(
+            attribute.type,
+            attribute,
+            AshGraphql.Test.ResourceWithEmptyInputEmbed,
+            true
+          )
+      end)
+
+    assert stderr =~ "Embedded type"
+    assert stderr =~ "cannot define a GraphQL input type"
+    assert stderr =~ "no input fields were produced"
+    assert stderr =~ "accept lists"
+    assert stderr =~ "Application.get_env(:ash_graphql, :json_type)"
   end
 end

--- a/test/support/resources/empty_input_embed.ex
+++ b/test/support/resources/empty_input_embed.ex
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.EmptyInputEmbed do
+  @moduledoc false
+
+  use Ash.Resource,
+    data_layer: :embedded,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type :empty_input_embed
+  end
+
+  actions do
+    create :create do
+      primary?(true)
+      accept([])
+    end
+
+    update :update do
+      primary?(true)
+      accept([])
+    end
+  end
+
+  attributes do
+    attribute :type, :atom do
+      public?(true)
+      writable?(false)
+      constraints(one_of: [:empty_input_embed])
+    end
+  end
+end
+
+defmodule AshGraphql.Test.ResourceWithEmptyInputEmbed do
+  @moduledoc false
+
+  use Ash.Resource,
+    domain: nil,
+    data_layer: Ash.DataLayer.Ets,
+    extensions: [AshGraphql.Resource]
+
+  graphql do
+    type :resource_with_empty_input_embed
+  end
+
+  actions do
+    default_accept(:*)
+    defaults([:read])
+  end
+
+  attributes do
+    uuid_primary_key(:id)
+
+    attribute :empty_value, AshGraphql.Test.EmptyInputEmbed do
+      public?(true)
+    end
+  end
+end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests - Issue #223 is a bug (bad warning).
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary
Improves the warning when an embedded type is used as GraphQL input but no input fields are produced (example used in test case is an empty 'accept' on create/update) instead of using the cryptic warning described in the initial issue description.

## Related Issue
Fixes #223 

## Behavior
Warning text only; fallback to 'json_type' / ':json_string' is unchanged.

## Testing
'mix test test/issue_223_repro_test.exs'
Full suite in WSL was tested as well.
