### PR TITLE
Add tests for Ash.Type.Enum and Ash.Type.NewType types descriptions

### DIFF
--- a/test/enum_test.exs
+++ b/test/enum_test.exs
@@ -85,4 +85,46 @@ defmodule AshGraphql.EnumTest do
              data["__type"]["enumValues"]
              |> Enum.find(fn value -> value["name"] == "NO_DESCRIPTION" end)
   end
+
+  test "Ash.Type.Enum type-level description flows through to GraphQL schema" do
+    {:ok, %{data: data}} =
+      """
+      query {
+        __type(name: "EnumWithAshTypeDescription") {
+          description
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    assert data["__type"]["description"] == "A yes or no type-level description"
+  end
+
+  test "enum without graphql_description/1 has nil type-level description" do
+    {:ok, %{data: data}} =
+      """
+      query {
+        __type(name: "EnumWithAshGraphqlDescription") {
+          description
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    assert data["__type"]["description"] == nil
+  end
+
+  test "graphql_description/1 sets type-level description for Ash.Type.NewType" do
+    {:ok, %{data: data}} =
+      """
+      query {
+        __type(name: "NewTypeWithDescription") {
+          description
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    assert data["__type"]["description"] == "A described NewType"
+  end
 end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -563,6 +563,12 @@ defmodule AshGraphql.Test.Post do
     attribute(:status, AshGraphql.Test.Status, public?: true)
     attribute(:status_enum, AshGraphql.Test.StatusEnum, public?: true)
 
+    attribute(:new_type_with_description, AshGraphql.Test.NewTypeWithDescription, public?: true)
+
+    attribute(:enum_with_ash_type_description, AshGraphql.Test.EnumWithAshTypeDescription,
+      public?: true
+    )
+
     attribute(:enum_with_ash_graphql_description, AshGraphql.Test.EnumWithAshGraphqlDescription,
       public?: true
     )

--- a/test/support/types/enum_with_ash_type_description.ex
+++ b/test/support/types/enum_with_ash_type_description.ex
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.EnumWithAshTypeDescription do
+  @moduledoc false
+  use Ash.Type.Enum, values: [:yes, :no]
+  use AshGraphql.Type
+
+  @impl AshGraphql.Type
+  def graphql_type(_), do: :enum_with_ash_type_description
+
+  @impl AshGraphql.Type
+  def graphql_description(_), do: "A yes or no type-level description"
+end

--- a/test/support/types/new_type_with_description.ex
+++ b/test/support/types/new_type_with_description.ex
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.Test.NewTypeWithDescription do
+  @moduledoc false
+  use Ash.Type.NewType,
+    subtype_of: :map,
+    constraints: [
+      fields: [
+        value: [type: :string, allow_nil?: false]
+      ]
+    ]
+
+  use AshGraphql.Type
+
+  @impl AshGraphql.Type
+  def graphql_type(_), do: :new_type_with_description
+
+  @impl AshGraphql.Type
+  def graphql_input_type(_), do: :new_type_with_description_input
+
+  @impl AshGraphql.Type
+  def graphql_description(_), do: "A described NewType"
+end


### PR DESCRIPTION
# Add graphql_description/1 callback support for Ash.Type.Enum and Ash.Type.NewType

## Contributor checklist
Leave anything that you believe does not apply unchecked.
- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

Closes #292

## Feature

Adds support for type-level descriptions on `Ash.Type.Enum` and `Ash.Type.NewType` types in the generated GraphQL schema, as specified by @zachdaniel in the issue.

## Implementation

The `graphql_description/1` callback on `AshGraphql.Type` (takes constraints, returns `String.t() | nil`) was already defined in `lib/type.ex`, and `AshGraphql.Type.description/2` was already being called at the relevant callsites in `lib/ash_graphql.ex` (for enums, in `global_enums/4`) and `lib/resource/resource.ex` (for NewTypes, at all map/union type definition paths).

To use the feature, implement `graphql_description/1` on any `Ash.Type.Enum` or `Ash.Type.NewType`:

```elixir
defmodule MyApp.MyEnum do
  use Ash.Type.Enum, values: [:foo, :bar]
  use AshGraphql.Type

  def graphql_type(_), do: :my_enum
  def graphql_description(_), do: "A description that appears in the GraphQL schema"
end
```

## Testing

Three tests added to `test/enum_test.exs`:

1. **Enum type-level description flows through** — asserts that `graphql_description/1` on an `Ash.Type.Enum` surfaces on the GraphQL type via `__type` introspection
2. **Enum without description returns nil** — regression guard confirming enum types without `graphql_description/1` are unaffected
3. **NewType description flows through** — asserts that `graphql_description/1` on an `Ash.Type.NewType` surfaces on the generated GraphQL type via `__type` introspection

Two new test support types added:
- `test/support/types/enum_with_ash_type_description.ex`
- `test/support/types/new_type_with_description.ex`