### PR TITLE
fix: traverse struct NewType fields so nested types get registered in the schema

### DIFF
--- a/lib/ash_graphql.ex
+++ b/lib/ash_graphql.ex
@@ -780,7 +780,6 @@ defmodule AshGraphql do
         |> all_attributes_and_arguments(all_domains, already_checked, true)
 
       Ash.Type.NewType.new_type?(type) && type not in already_checked ->
-        already_checked = [type | already_checked]
         constraints = Ash.Type.NewType.constraints(type, constraints)
         subtype = Ash.Type.NewType.subtype_of(type)
 
@@ -797,7 +796,7 @@ defmodule AshGraphql do
 
           {[fake_attr], already_checked}
         else
-          nested_attrs(subtype, all_domains, constraints, already_checked)
+          nested_attrs(subtype, all_domains, constraints, [type | already_checked])
         end
 
       true ->

--- a/test/nested_struct_enum_test.exs
+++ b/test/nested_struct_enum_test.exs
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.NestedStructEnumTest do
+  use ExUnit.Case, async: true
+
+  defmodule EnumViaCalc do
+    @moduledoc false
+    use Ash.Type.Enum, values: [:low, :high]
+    def graphql_type(_), do: :nested_struct_enum_via_calc
+  end
+
+  defmodule StructViaCalc do
+    @moduledoc false
+    use Ash.TypedStruct
+
+    typed_struct do
+      field(:field, EnumViaCalc)
+    end
+
+    def graphql_type(_), do: :nested_struct_via_calc
+  end
+
+  defmodule EnumViaAttribute do
+    @moduledoc false
+    use Ash.Type.Enum, values: [:low, :high]
+    def graphql_type(_), do: :nested_struct_enum_via_attribute
+  end
+
+  defmodule StructViaAttribute do
+    @moduledoc false
+    use Ash.TypedStruct
+
+    typed_struct do
+      field(:field, EnumViaAttribute)
+    end
+
+    def graphql_type(_), do: :nested_struct_via_attribute
+  end
+
+  defmodule Thing do
+    @moduledoc false
+    use Ash.Resource,
+      domain: AshGraphql.NestedStructEnumTest.Domain,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshGraphql.Resource]
+
+    attributes do
+      uuid_primary_key(:id)
+
+      attribute :struct_via_attribute, AshGraphql.NestedStructEnumTest.StructViaAttribute do
+        public?(true)
+      end
+    end
+
+    actions do
+      defaults([:read])
+    end
+
+    calculations do
+      calculate :struct_via_calc, AshGraphql.NestedStructEnumTest.StructViaCalc, expr(nil) do
+        public?(true)
+      end
+    end
+
+    graphql do
+      type :nested_struct_enum_thing
+
+      queries do
+        list :things, :read
+      end
+    end
+  end
+
+  defmodule Domain do
+    @moduledoc false
+    use Ash.Domain, otp_app: :ash_graphql, extensions: [AshGraphql.Domain]
+
+    resources do
+      resource(AshGraphql.NestedStructEnumTest.Thing)
+    end
+  end
+
+  defmodule Schema do
+    @moduledoc false
+    use Absinthe.Schema
+    use AshGraphql, domains: [AshGraphql.NestedStructEnumTest.Domain]
+
+    query do
+    end
+  end
+
+  test "an enum nested in a struct reached only via a calculation is registered" do
+    assert %Absinthe.Type.Enum{} =
+             Absinthe.Schema.lookup_type(Schema, :nested_struct_enum_via_calc)
+
+    assert Absinthe.Schema.to_sdl(Schema) =~ "field: NestedStructEnumViaCalc"
+  end
+
+  test "an enum nested in a struct reached only via an attribute is registered" do
+    assert %Absinthe.Type.Enum{} =
+             Absinthe.Schema.lookup_type(Schema, :nested_struct_enum_via_attribute)
+
+    assert Absinthe.Schema.to_sdl(Schema) =~ "field: NestedStructEnumViaAttribute"
+  end
+end


### PR DESCRIPTION
Custom types nested in struct NewTypes don't show up in the schema when those structs appear indirectly, like in a calculation. This PR fixes that traversal path

# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
