### PR TITLE
fix: preserve remaining GraphQL filters

### DIFF
--- a/lib/graphql/filter_handlers.ex
+++ b/lib/graphql/filter_handlers.ex
@@ -25,7 +25,7 @@ defmodule AshGraphql.Graphql.FilterHandlers do
 
     filter_input =
       case remaining do
-        %{} -> nil
+        remaining when remaining == %{} -> nil
         rest -> Resolver.massage_filter(resource, rest)
       end
 

--- a/test/filter_handlers_test.exs
+++ b/test/filter_handlers_test.exs
@@ -5,6 +5,7 @@
 defmodule AshGraphql.FilterHandlersTest do
   use ExUnit.Case, async: false
 
+  alias AshGraphql.Graphql.FilterHandlers
   alias AshGraphql.Test.PubSub
   alias AshGraphql.Test.RelayIds.{BaseImage, Schema}
 
@@ -47,6 +48,29 @@ defmodule AshGraphql.FilterHandlersTest do
     end
   end
 
+  describe "filter_handlers apply_filter" do
+    test "keeps non-empty ordinary field filters" do
+      assert {:ok, [name: %{eq: "hero"}], []} =
+               FilterHandlers.apply_filter(BaseImage, %{name: %{eq: "hero"}}, %{})
+    end
+
+    test "keeps ordinary field filters alongside handler expressions" do
+      image =
+        BaseImage
+        |> Ash.Changeset.for_create(:create, %{name: "hero"})
+        |> Ash.create!()
+
+      relay_id = AshGraphql.Resource.encode_relay_id(image)
+
+      assert {:ok, [name: %{eq: "missing"}], [_expr]} =
+               FilterHandlers.apply_filter(
+                 BaseImage,
+                 %{id: %{eq: relay_id}, name: %{eq: "missing"}},
+                 %{}
+               )
+    end
+  end
+
   describe "filter_handlers queries" do
     test "list query filters by relay global id with eq" do
       image =
@@ -81,6 +105,35 @@ defmodule AshGraphql.FilterHandlersTest do
              ]
 
       refute relay_id == AshGraphql.Resource.encode_relay_id(other)
+    end
+
+    test "list query applies ordinary field filters alongside relay global id filters" do
+      image =
+        BaseImage
+        |> Ash.Changeset.for_create(:create, %{name: "hero"})
+        |> Ash.create!()
+
+      relay_id = AshGraphql.Resource.encode_relay_id(image)
+
+      assert {:ok, result} =
+               """
+               query ListBaseImages($filter: BaseImageFilterInput) {
+                 listBaseImages(filter: $filter) {
+                   results {
+                     id
+                     name
+                   }
+                 }
+               }
+               """
+               |> Absinthe.run(Schema,
+                 variables: %{
+                   "filter" => %{"id" => %{"eq" => relay_id}, "name" => %{"eq" => "missing"}}
+                 }
+               )
+
+      refute Map.has_key?(result, :errors)
+      assert result.data["listBaseImages"]["results"] == []
     end
 
     test "list query filters by relay global id with in" do
@@ -151,6 +204,53 @@ defmodule AshGraphql.FilterHandlersTest do
   end
 
   describe "filter_handlers subscriptions" do
+    test "subscription applies ordinary field filters" do
+      blocked =
+        BaseImage
+        |> Ash.Changeset.for_create(:create, %{name: "blocked"})
+        |> Ash.create!()
+
+      allowed =
+        BaseImage
+        |> Ash.Changeset.for_create(:create, %{name: "pending"})
+        |> Ash.create!()
+
+      allowed_relay_id = AshGraphql.Resource.encode_relay_id(allowed)
+
+      assert {:ok, %{"subscribed" => topic}} =
+               """
+               subscription BaseImageEvents($filter: BaseImageFilterInput) {
+                 baseImageEvents(filter: $filter) {
+                   updated {
+                     id
+                     name
+                   }
+                 }
+               }
+               """
+               |> Absinthe.run(Schema,
+                 variables: %{"filter" => %{"name" => %{"eq" => "allowed"}}},
+                 context: %{pubsub: PubSub}
+               )
+
+      blocked
+      |> Ash.Changeset.for_update(:update, %{name: "blocked-updated"})
+      |> Ash.update!()
+
+      refute_receive {^topic, _}
+
+      allowed
+      |> Ash.Changeset.for_update(:update, %{name: "allowed"})
+      |> Ash.update!()
+
+      assert_receive {^topic, %{data: subscription_data}}
+
+      assert subscription_data["baseImageEvents"]["updated"] == %{
+               "id" => allowed_relay_id,
+               "name" => "allowed"
+             }
+    end
+
     test "subscription filter accepts relay global id" do
       image =
         BaseImage


### PR DESCRIPTION
[This recent commit on ash_graphql main branch](https://github.com/ash-project/ash_graphql/commit/0a52795fd7d5896bc313a8c9ea99dc5260a6a3d5) has introduced a regression that was surfaced in my own project's test suite.

The previous empty-map match treated every remaining filter map as empty, so non-handler field filters were dropped before reaching Ash.

Cover handler, query, and subscription paths to prevent filtered GraphQL operations from returning records that should be excluded.

I used AI to diagnose and fix this issue, however I have personally checked and understand the changes.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [x] Chores
