### PR TITLE
Expose relationship read action arguments as GraphQL defaults

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5233,10 +5233,10 @@ defmodule AshGraphql.Resource do
   defp argument_required?(_), do: true
 
   defp apply_relationship_argument_defaults(arguments, relationship) do
-    default_arguments = Map.get(relationship, :read_action_argument_defaults, %{})
+    relationship_arguments = Map.get(relationship, :read_action_arguments, %{})
 
     Enum.map(arguments, fn argument ->
-      case Map.fetch(default_arguments, argument.identifier) do
+      case Map.fetch(relationship_arguments, argument.identifier) do
         {:ok, default_value} ->
           %{argument | default_value: default_value}
 

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5238,13 +5238,7 @@ defmodule AshGraphql.Resource do
     Enum.map(arguments, fn argument ->
       case Map.fetch(default_arguments, argument.identifier) do
         {:ok, default_value} ->
-          type =
-            case argument.type do
-              %Absinthe.Blueprint.TypeReference.NonNull{of_type: type} -> type
-              type -> type
-            end
-
-          %{argument | type: type, default_value: default_value}
+          %{argument | default_value: default_value}
 
         :error ->
           argument

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5232,7 +5232,7 @@ defmodule AshGraphql.Resource do
   defp argument_required?(%{default: default}) when not is_nil(default), do: false
   defp argument_required?(_), do: true
 
-  defp optionalize_relationship_argument_defaults(arguments, relationship) do
+  defp optionalize_arguments_with_relationship_defaults(arguments, relationship) do
     default_arguments = Map.get(relationship, :read_action_argument_defaults, %{})
 
     Enum.map(arguments, fn
@@ -5278,7 +5278,7 @@ defmodule AshGraphql.Resource do
           arguments:
             :one_related
             |> args(relationship.destination, read_action, schema)
-            |> optionalize_relationship_argument_defaults(relationship),
+            |> optionalize_arguments_with_relationship_defaults(relationship),
           middleware: [
             {{AshGraphql.Graphql.Resolver, :resolve_assoc_one},
              {domain, relationship, materialized_singular_relationship?(resource, relationship)}}
@@ -5323,7 +5323,7 @@ defmodule AshGraphql.Resource do
               read_action,
               schema
             )
-            |> optionalize_relationship_argument_defaults(relationship),
+            |> optionalize_arguments_with_relationship_defaults(relationship),
           type: query_type,
           __reference__: ref(__ENV__)
         }

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5232,7 +5232,7 @@ defmodule AshGraphql.Resource do
   defp argument_required?(%{default: default}) when not is_nil(default), do: false
   defp argument_required?(_), do: true
 
-  defp optionalize_relationship_default_arguments(arguments, relationship) do
+  defp optionalize_relationship_argument_defaults(arguments, relationship) do
     default_arguments = Map.get(relationship, :read_action_argument_defaults, %{})
 
     Enum.map(arguments, fn
@@ -5278,7 +5278,7 @@ defmodule AshGraphql.Resource do
           arguments:
             :one_related
             |> args(relationship.destination, read_action, schema)
-            |> optionalize_relationship_default_arguments(relationship),
+            |> optionalize_relationship_argument_defaults(relationship),
           middleware: [
             {{AshGraphql.Graphql.Resolver, :resolve_assoc_one},
              {domain, relationship, materialized_singular_relationship?(resource, relationship)}}
@@ -5323,7 +5323,7 @@ defmodule AshGraphql.Resource do
               read_action,
               schema
             )
-            |> optionalize_relationship_default_arguments(relationship),
+            |> optionalize_relationship_argument_defaults(relationship),
           type: query_type,
           __reference__: ref(__ENV__)
         }

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5232,22 +5232,23 @@ defmodule AshGraphql.Resource do
   defp argument_required?(%{default: default}) when not is_nil(default), do: false
   defp argument_required?(_), do: true
 
-  defp optionalize_arguments_with_relationship_defaults(arguments, relationship) do
+  defp apply_relationship_argument_defaults(arguments, relationship) do
     default_arguments = Map.get(relationship, :read_action_argument_defaults, %{})
 
-    Enum.map(arguments, fn
-      %{
-        identifier: identifier,
-        type: %Absinthe.Blueprint.TypeReference.NonNull{of_type: type}
-      } = argument ->
-        if Map.has_key?(default_arguments, identifier) do
-          %{argument | type: type}
-        else
-          argument
-        end
+    Enum.map(arguments, fn argument ->
+      case Map.fetch(default_arguments, argument.identifier) do
+        {:ok, default_value} ->
+          type =
+            case argument.type do
+              %Absinthe.Blueprint.TypeReference.NonNull{of_type: type} -> type
+              type -> type
+            end
 
-      argument ->
-        argument
+          %{argument | type: type, default_value: default_value}
+
+        :error ->
+          argument
+      end
     end)
   end
 
@@ -5278,7 +5279,7 @@ defmodule AshGraphql.Resource do
           arguments:
             :one_related
             |> args(relationship.destination, read_action, schema)
-            |> optionalize_arguments_with_relationship_defaults(relationship),
+            |> apply_relationship_argument_defaults(relationship),
           middleware: [
             {{AshGraphql.Graphql.Resolver, :resolve_assoc_one},
              {domain, relationship, materialized_singular_relationship?(resource, relationship)}}
@@ -5323,7 +5324,7 @@ defmodule AshGraphql.Resource do
               read_action,
               schema
             )
-            |> optionalize_arguments_with_relationship_defaults(relationship),
+            |> apply_relationship_argument_defaults(relationship),
           type: query_type,
           __reference__: ref(__ENV__)
         }

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -5232,6 +5232,25 @@ defmodule AshGraphql.Resource do
   defp argument_required?(%{default: default}) when not is_nil(default), do: false
   defp argument_required?(_), do: true
 
+  defp optionalize_relationship_default_arguments(arguments, relationship) do
+    default_arguments = Map.get(relationship, :read_action_argument_defaults, %{})
+
+    Enum.map(arguments, fn
+      %{
+        identifier: identifier,
+        type: %Absinthe.Blueprint.TypeReference.NonNull{of_type: type}
+      } = argument ->
+        if Map.has_key?(default_arguments, identifier) do
+          %{argument | type: type}
+        else
+          argument
+        end
+
+      argument ->
+        argument
+    end)
+  end
+
   # sobelow_skip ["DOS.StringToAtom"]
   defp relationships(resource, domain, schema) do
     field_names = AshGraphql.Resource.Info.field_names(resource)
@@ -5256,7 +5275,10 @@ defmodule AshGraphql.Resource do
           module: schema,
           name: to_string(name),
           description: relationship.description,
-          arguments: args(:one_related, relationship.destination, read_action, schema),
+          arguments:
+            :one_related
+            |> args(relationship.destination, read_action, schema)
+            |> optionalize_relationship_default_arguments(relationship),
           middleware: [
             {{AshGraphql.Graphql.Resolver, :resolve_assoc_one},
              {domain, relationship, materialized_singular_relationship?(resource, relationship)}}
@@ -5300,7 +5322,8 @@ defmodule AshGraphql.Resource do
               relationship.name,
               read_action,
               schema
-            ),
+            )
+            |> optionalize_relationship_default_arguments(relationship),
           type: query_type,
           __reference__: ref(__ENV__)
         }

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -47,7 +47,7 @@ defmodule AshGraphql.ResourceTest do
       Enum.find(relationship_with_defaults["args"], &(&1["name"] == "prefix"))
 
     nullable_argument_with_default =
-      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalPrefix"))
+      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalLimit"))
 
     assert required_argument["type"]["kind"] == "NON_NULL"
     assert is_nil(required_argument["defaultValue"])
@@ -56,7 +56,7 @@ defmodule AshGraphql.ResourceTest do
     assert argument_with_default["defaultValue"] == ~s("default")
 
     refute nullable_argument_with_default["type"]["kind"] == "NON_NULL"
-    assert nullable_argument_with_default["defaultValue"] == ~s("optional default")
+    assert nullable_argument_with_default["defaultValue"] == "30"
 
     post =
       AshGraphql.Test.Post
@@ -74,7 +74,7 @@ defmodule AshGraphql.ResourceTest do
              """
              query {
                getPost(id: "#{post.id}") {
-                 commentsWithDefaultArgument(optionalPrefix: null) {
+                 commentsWithDefaultArgument(optionalLimit: null) {
                    id
                  }
                }

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -14,6 +14,32 @@ defmodule AshGraphql.ResourceTest do
     assert nil == Absinthe.Schema.lookup_type(AshGraphql.Test.Schema, :no_object)
   end
 
+  test "relationship read action arguments with defaults are optional" do
+    {:ok, %{data: %{"__type" => %{"fields" => fields}}}} =
+      """
+      query {
+        __type(name: "Post") {
+          fields {
+            name
+            args {
+              name
+              type {
+                kind
+              }
+            }
+          }
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema)
+
+    relationship =
+      Enum.find(fields, &(&1["name"] == "commentsWithDefaultArgument"))
+
+    assert %{"type" => %{"kind" => "SCALAR"}} =
+             Enum.find(relationship["args"], &(&1["name"] == "prefix"))
+  end
+
   test "resource with no type can execute generic queries" do
     resp =
       """

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -23,6 +23,7 @@ defmodule AshGraphql.ResourceTest do
             name
             args {
               name
+              defaultValue
               type {
                 kind
               }
@@ -36,17 +37,20 @@ defmodule AshGraphql.ResourceTest do
     required_relationship =
       Enum.find(fields, &(&1["name"] == "commentsWithRequiredArgument"))
 
-    defaulted_relationship =
+    relationship_with_defaults =
       Enum.find(fields, &(&1["name"] == "commentsWithDefaultArgument"))
 
     required_argument =
       Enum.find(required_relationship["args"], &(&1["name"] == "prefix"))
 
-    defaulted_argument =
-      Enum.find(defaulted_relationship["args"], &(&1["name"] == "prefix"))
+    argument_with_default =
+      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "prefix"))
 
     assert required_argument["type"]["kind"] == "NON_NULL"
-    refute defaulted_argument["type"]["kind"] == "NON_NULL"
+    assert is_nil(required_argument["defaultValue"])
+
+    refute argument_with_default["type"]["kind"] == "NON_NULL"
+    assert argument_with_default["defaultValue"] == ~s("default")
   end
 
   test "resource with no type can execute generic queries" do

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -14,7 +14,7 @@ defmodule AshGraphql.ResourceTest do
     assert nil == Absinthe.Schema.lookup_type(AshGraphql.Test.Schema, :no_object)
   end
 
-  test "relationship read action arguments with defaults are optional" do
+  test "relationship read action arguments are exposed as GraphQL defaults" do
     {:ok, %{data: %{"__type" => %{"fields" => fields}}}} =
       """
       query {
@@ -37,21 +37,21 @@ defmodule AshGraphql.ResourceTest do
     required_relationship =
       Enum.find(fields, &(&1["name"] == "commentsWithRequiredArgument"))
 
-    relationship_with_defaults =
-      Enum.find(fields, &(&1["name"] == "commentsWithDefaultArgument"))
+    relationship_with_arguments =
+      Enum.find(fields, &(&1["name"] == "commentsWithRelationshipArguments"))
 
     required_argument =
       Enum.find(required_relationship["args"], &(&1["name"] == "prefix"))
 
     argument_with_default =
-      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "prefix"))
+      Enum.find(relationship_with_arguments["args"], &(&1["name"] == "prefix"))
 
     nullable_argument_with_default =
-      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalPrefix"))
+      Enum.find(relationship_with_arguments["args"], &(&1["name"] == "optionalPrefix"))
 
-    argument_with_action_and_relationship_defaults =
+    argument_with_action_default_and_relationship_argument =
       Enum.find(
-        relationship_with_defaults["args"],
+        relationship_with_arguments["args"],
         &(&1["name"] == "actionDefaultPrefix")
       )
 
@@ -64,8 +64,8 @@ defmodule AshGraphql.ResourceTest do
     refute nullable_argument_with_default["type"]["kind"] == "NON_NULL"
     assert nullable_argument_with_default["defaultValue"] == ~s("optional default")
 
-    assert argument_with_action_and_relationship_defaults["defaultValue"] ==
-             ~s("relationship default")
+    assert argument_with_action_default_and_relationship_argument["defaultValue"] ==
+             ~s("relationship argument")
 
     post =
       AshGraphql.Test.Post
@@ -77,13 +77,13 @@ defmodule AshGraphql.ResourceTest do
     assert {:ok,
             %{
               data: %{
-                "getPost" => %{"commentsWithDefaultArgument" => []}
+                "getPost" => %{"commentsWithRelationshipArguments" => []}
               }
             }} =
              """
              query {
                getPost(id: "#{post.id}") {
-                 commentsWithDefaultArgument(optionalPrefix: null) {
+                 commentsWithRelationshipArguments(optionalPrefix: null) {
                    id
                  }
                }

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -33,13 +33,20 @@ defmodule AshGraphql.ResourceTest do
       """
       |> Absinthe.run(AshGraphql.Test.Schema)
 
-    relationship =
+    required_relationship =
+      Enum.find(fields, &(&1["name"] == "commentsWithRequiredArgument"))
+
+    defaulted_relationship =
       Enum.find(fields, &(&1["name"] == "commentsWithDefaultArgument"))
 
-    argument =
-      Enum.find(relationship["args"], &(&1["name"] == "prefix"))
+    required_argument =
+      Enum.find(required_relationship["args"], &(&1["name"] == "prefix"))
 
-    refute argument["type"]["kind"] == "NON_NULL"
+    defaulted_argument =
+      Enum.find(defaulted_relationship["args"], &(&1["name"] == "prefix"))
+
+    assert required_argument["type"]["kind"] == "NON_NULL"
+    refute defaulted_argument["type"]["kind"] == "NON_NULL"
   end
 
   test "resource with no type can execute generic queries" do

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -36,8 +36,10 @@ defmodule AshGraphql.ResourceTest do
     relationship =
       Enum.find(fields, &(&1["name"] == "commentsWithDefaultArgument"))
 
-    assert %{"type" => %{"kind" => "SCALAR"}} =
-             Enum.find(relationship["args"], &(&1["name"] == "prefix"))
+    argument =
+      Enum.find(relationship["args"], &(&1["name"] == "prefix"))
+
+    refute argument["type"]["kind"] == "NON_NULL"
   end
 
   test "resource with no type can execute generic queries" do

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -46,11 +46,55 @@ defmodule AshGraphql.ResourceTest do
     argument_with_default =
       Enum.find(relationship_with_defaults["args"], &(&1["name"] == "prefix"))
 
+    nullable_argument_with_default =
+      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalPrefix"))
+
     assert required_argument["type"]["kind"] == "NON_NULL"
     assert is_nil(required_argument["defaultValue"])
 
-    refute argument_with_default["type"]["kind"] == "NON_NULL"
+    assert argument_with_default["type"]["kind"] == "NON_NULL"
     assert argument_with_default["defaultValue"] == ~s("default")
+
+    refute nullable_argument_with_default["type"]["kind"] == "NON_NULL"
+    assert nullable_argument_with_default["defaultValue"] == ~s("optional default")
+
+    post =
+      AshGraphql.Test.Post
+      |> Ash.Changeset.for_create(:create, text: "post", published: true, score: 1.0)
+      |> Ash.create!()
+
+    on_exit(fn -> AshGraphql.TestHelpers.stop_ets() end)
+
+    assert {:ok,
+            %{
+              data: %{
+                "getPost" => %{"commentsWithDefaultArgument" => []}
+              }
+            }} =
+             """
+             query {
+               getPost(id: "#{post.id}") {
+                 commentsWithDefaultArgument(optionalPrefix: null) {
+                   id
+                 }
+               }
+             }
+             """
+             |> Absinthe.run(AshGraphql.Test.Schema)
+
+    assert {:ok, %{errors: errors}} =
+             """
+             query {
+               getPost(id: "#{post.id}") {
+                 commentsWithRequiredArgument {
+                   id
+                 }
+               }
+             }
+             """
+             |> Absinthe.run(AshGraphql.Test.Schema)
+
+    assert Enum.any?(errors, &String.contains?(&1.message, "prefix"))
   end
 
   test "resource with no type can execute generic queries" do

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -47,7 +47,7 @@ defmodule AshGraphql.ResourceTest do
       Enum.find(relationship_with_defaults["args"], &(&1["name"] == "prefix"))
 
     nullable_argument_with_default =
-      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalLimit"))
+      Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalPrefix"))
 
     assert required_argument["type"]["kind"] == "NON_NULL"
     assert is_nil(required_argument["defaultValue"])
@@ -56,7 +56,7 @@ defmodule AshGraphql.ResourceTest do
     assert argument_with_default["defaultValue"] == ~s("default")
 
     refute nullable_argument_with_default["type"]["kind"] == "NON_NULL"
-    assert nullable_argument_with_default["defaultValue"] == "30"
+    assert nullable_argument_with_default["defaultValue"] == ~s("optional default")
 
     post =
       AshGraphql.Test.Post
@@ -74,7 +74,7 @@ defmodule AshGraphql.ResourceTest do
              """
              query {
                getPost(id: "#{post.id}") {
-                 commentsWithDefaultArgument(optionalLimit: null) {
+                 commentsWithDefaultArgument(optionalPrefix: null) {
                    id
                  }
                }

--- a/test/resource_test.exs
+++ b/test/resource_test.exs
@@ -49,6 +49,12 @@ defmodule AshGraphql.ResourceTest do
     nullable_argument_with_default =
       Enum.find(relationship_with_defaults["args"], &(&1["name"] == "optionalPrefix"))
 
+    argument_with_action_and_relationship_defaults =
+      Enum.find(
+        relationship_with_defaults["args"],
+        &(&1["name"] == "actionDefaultPrefix")
+      )
+
     assert required_argument["type"]["kind"] == "NON_NULL"
     assert is_nil(required_argument["defaultValue"])
 
@@ -57,6 +63,9 @@ defmodule AshGraphql.ResourceTest do
 
     refute nullable_argument_with_default["type"]["kind"] == "NON_NULL"
     assert nullable_argument_with_default["defaultValue"] == ~s("optional default")
+
+    assert argument_with_action_and_relationship_defaults["defaultValue"] ==
+             ~s("relationship default")
 
     post =
       AshGraphql.Test.Post

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -43,7 +43,7 @@ defmodule AshGraphql.Test.Comment do
 
     read :with_default_argument do
       argument(:prefix, :string, allow_nil?: false)
-      argument(:optional_prefix, :string)
+      argument(:optional_limit, :integer)
     end
 
     action :ranked_comments, {:array, RankedComment} do

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -43,7 +43,7 @@ defmodule AshGraphql.Test.Comment do
 
     read :with_default_argument do
       argument(:prefix, :string, allow_nil?: false)
-      argument(:optional_limit, :integer)
+      argument(:optional_prefix, :string)
     end
 
     action :ranked_comments, {:array, RankedComment} do

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -44,6 +44,7 @@ defmodule AshGraphql.Test.Comment do
     read :with_default_argument do
       argument(:prefix, :string, allow_nil?: false)
       argument(:optional_prefix, :string)
+      argument(:action_default_prefix, :string, default: "action default")
     end
 
     action :ranked_comments, {:array, RankedComment} do

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -43,6 +43,7 @@ defmodule AshGraphql.Test.Comment do
 
     read :with_default_argument do
       argument(:prefix, :string, allow_nil?: false)
+      argument(:optional_prefix, :string)
     end
 
     action :ranked_comments, {:array, RankedComment} do

--- a/test/support/resources/comment.ex
+++ b/test/support/resources/comment.ex
@@ -41,6 +41,10 @@ defmodule AshGraphql.Test.Comment do
       pagination(required?: true, offset?: true, countable: true)
     end
 
+    read :with_default_argument do
+      argument(:prefix, :string, allow_nil?: false)
+    end
+
     action :ranked_comments, {:array, RankedComment} do
       run(fn _input, _ctx ->
         res =

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -712,7 +712,8 @@ defmodule AshGraphql.Test.Post do
 
       read_action_argument_defaults(%{
         prefix: "default",
-        optional_prefix: "optional default"
+        optional_prefix: "optional default",
+        action_default_prefix: "relationship default"
       })
     end
 

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -712,7 +712,7 @@ defmodule AshGraphql.Test.Post do
 
       read_action_argument_defaults(%{
         prefix: "default",
-        optional_limit: 30
+        optional_prefix: "optional default"
       })
     end
 

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -709,7 +709,11 @@ defmodule AshGraphql.Test.Post do
     has_many :comments_with_default_argument, AshGraphql.Test.Comment do
       public?(true)
       read_action(:with_default_argument)
-      read_action_argument_defaults(%{prefix: "default"})
+
+      read_action_argument_defaults(%{
+        prefix: "default",
+        optional_prefix: "optional default"
+      })
     end
 
     has_many(:sponsored_comments, AshGraphql.Test.SponsoredComment, public?: true)

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -700,6 +700,13 @@ defmodule AshGraphql.Test.Post do
     end
 
     has_many(:comments, AshGraphql.Test.Comment, public?: true)
+
+    has_many :comments_with_default_argument, AshGraphql.Test.Comment do
+      public?(true)
+      read_action(:with_default_argument)
+      read_action_argument_defaults(%{prefix: "default"})
+    end
+
     has_many(:sponsored_comments, AshGraphql.Test.SponsoredComment, public?: true)
     has_many(:paginated_comments, AshGraphql.Test.Comment, read_action: :paginated, public?: true)
 

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -706,14 +706,14 @@ defmodule AshGraphql.Test.Post do
       read_action(:with_default_argument)
     end
 
-    has_many :comments_with_default_argument, AshGraphql.Test.Comment do
+    has_many :comments_with_relationship_arguments, AshGraphql.Test.Comment do
       public?(true)
       read_action(:with_default_argument)
 
-      read_action_argument_defaults(%{
+      read_action_arguments(%{
         prefix: "default",
         optional_prefix: "optional default",
-        action_default_prefix: "relationship default"
+        action_default_prefix: "relationship argument"
       })
     end
 

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -701,6 +701,11 @@ defmodule AshGraphql.Test.Post do
 
     has_many(:comments, AshGraphql.Test.Comment, public?: true)
 
+    has_many :comments_with_required_argument, AshGraphql.Test.Comment do
+      public?(true)
+      read_action(:with_default_argument)
+    end
+
     has_many :comments_with_default_argument, AshGraphql.Test.Comment do
       public?(true)
       read_action(:with_default_argument)

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -712,7 +712,7 @@ defmodule AshGraphql.Test.Post do
 
       read_action_argument_defaults(%{
         prefix: "default",
-        optional_prefix: "optional default"
+        optional_limit: 30
       })
     end
 


### PR DESCRIPTION
## Summary

- Apply relationship `read_action_arguments` when generating GraphQL arguments for both singular and list relationships.
- Expose relationship-provided values as GraphQL defaults while preserving each action argument's original nullability.
- Allow nullable arguments to explicitly pass `null` instead of using the relationship-provided value.
- Prefer relationship arguments over read action defaults when both are configured.

Explicit GraphQL arguments still take precedence over relationship-provided arguments.

This builds on ash-project/ash#2775.

## Testing

- Added schema introspection coverage for required, nullable, action-defaulted, and relationship-provided arguments.
- Added execution coverage for omitted required arguments and explicit `null` values.
- `ASH_VERSION=local mix test test/resource_test.exs`

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
