### PR TITLE
fix: don't raise building error paths for maps without field constraints

### DIFF
--- a/lib/graphql/errors.ex
+++ b/lib/graphql/errors.ex
@@ -185,7 +185,7 @@ defmodule AshGraphql.Errors do
   end
 
   defp resolve_union_segment(segment, context) do
-    types = context.constraints[:types] || context.constraints["types"] || %{}
+    types = Keyword.get(context.constraints, :types, %{})
     segment_atom = segment_to_atom(segment)
 
     config =
@@ -219,7 +219,7 @@ defmodule AshGraphql.Errors do
   end
 
   defp resolve_map_struct_segment(segment, context) do
-    fields = context.constraints[:fields] || context.constraints["fields"] || []
+    fields = Keyword.get(context.constraints, :fields, [])
     segment_atom = segment_to_atom(segment)
 
     field_config =
@@ -259,7 +259,7 @@ defmodule AshGraphql.Errors do
         _ -> nil
       end
 
-    elem_constraints = context.constraints[:items] || context.constraints["items"] || []
+    elem_constraints = Keyword.get(context.constraints, :items, [])
     {elem_type, elem_constraints} = unwrap_type(elem_type, elem_constraints)
     inner_context = %{context | type: elem_type, constraints: elem_constraints}
     resolve_segment_with_context(segment, inner_context)
@@ -320,7 +320,7 @@ defmodule AshGraphql.Errors do
         :array
 
       type in [:map, Ash.Type.Map, :struct, Ash.Type.Struct] ->
-        if (constraints[:fields] || constraints["fields"] || []) != [], do: :map_struct, else: nil
+        if Keyword.get(constraints, :fields, []) != [], do: :map_struct, else: nil
 
       true ->
         if new_type?(type) do

--- a/test/errors_test.exs
+++ b/test/errors_test.exs
@@ -1287,5 +1287,26 @@ defmodule AshGraphql.ErrorsTest do
                }
              ] = errors
     end
+
+    test "path resolves a segment nested under a :map attribute with no :fields constraint" do
+      # A plain :map has constraints [preserve_nil_values?: false] — a keyword
+      # list with no :fields key — which is what makes the string-key lookup
+      # raise.
+      error =
+        Ash.Error.Forbidden.Policy.exception(vars: %{})
+        |> Ash.Error.set_path([:json_map, :some_key])
+
+      errors =
+        AshGraphql.Errors.to_errors(
+          [error],
+          %{},
+          AshGraphql.Test.Domain,
+          AshGraphql.Test.MapTypes,
+          Ash.Resource.Info.action(AshGraphql.Test.MapTypes, :update),
+          ["input"]
+        )
+
+      assert [%{code: "forbidden", path: ["input", "jsonMap", "someKey"]}] = errors
+    end
   end
 end


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

## Summary

Using `Ash.Changeset.add_error/3` or `Ash.Error.set_path/2` with a path that delves into `:map` types can swallow validation errors, returning a generic "Something went wrong" instead of the real error. This happens because `constraints` is a keyword list like `[preserve_nil_values?: false]`, and the `:fields` key is missing, so the `constraints["fields"]` fallback runs and raises on a keyword list looked up with a string key.

```elixir
iex(1)> x = [y: 1]
[y: 1]
iex(2)> x["hi"]
** (ArgumentError) the Access module supports only keyword lists (with atom keys), got: "hi"

If you want to search lists of tuples, use List.keyfind/3
    (elixir 1.20.2) lib/access.ex:362: Access.get/3
    iex:2: (file)
```

The same pattern appears four times (`:types`, `:fields` twice, `:items`). Only the `composite_kind/2` one raises today. The others have their atom key present, but I've changed all four since we never want to do `keyword_list["key"]`.

`add_error` and `set_path` do not prevent this kind of thing with their advertised type spec so this is something we walked into. This repo raises inside `build_error_path/5`, before both the resource and domain `error_handler` hooks, so there's no way to handle it from application code. #431 fixes a similar issue in this project, so I believe this belongs here.

The fix essentially removes the string fallback, which on a keyword list can only ever raise.