### PR TITLE
fix: support calculations in identities used by graphql queries

### DIFF
--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -1396,15 +1396,15 @@ defmodule AshGraphql.Resource do
     |> Enum.find(&(&1.name == identity))
     |> Map.get(:keys)
     |> Enum.map(fn key ->
-      attribute = Ash.Resource.Info.attribute(resource, key)
+      field = Ash.Resource.Info.field(resource, key)
 
       %Absinthe.Blueprint.Schema.InputValueDefinition{
         identifier: key,
         module: schema,
         name: to_string(key),
-        description: attribute.description || "",
+        description: field.description || "",
         type: %Absinthe.Blueprint.TypeReference.NonNull{
-          of_type: field_type(attribute.type, attribute, resource, false, schema)
+          of_type: field_type(field.type, field, resource, false, schema)
         },
         __reference__: ref(__ENV__)
       }
@@ -2286,15 +2286,15 @@ defmodule AshGraphql.Resource do
       |> Enum.find(&(&1.name == identity))
       |> Map.get(:keys)
       |> Enum.map(fn key ->
-        attribute = Ash.Resource.Info.attribute(resource, key)
+        field = Ash.Resource.Info.field(resource, key)
 
         %Absinthe.Blueprint.Schema.InputValueDefinition{
           name: to_string(key),
           identifier: key,
           type: %Absinthe.Blueprint.TypeReference.NonNull{
-            of_type: field_type(attribute.type, attribute, resource, true, schema)
+            of_type: field_type(field.type, field, resource, true, schema)
           },
-          description: attribute.description || "",
+          description: field.description || "",
           __reference__: ref(__ENV__)
         }
       end)

--- a/test/read_test.exs
+++ b/test/read_test.exs
@@ -1886,6 +1886,32 @@ defmodule AshGraphql.ReadTest do
     end
   end
 
+  test "a get query with an identity made up of a calculation works" do
+    tag =
+      AshGraphql.Test.Tag
+      |> Ash.Changeset.for_create(:create, %{name: "foo", popularity: 1})
+      |> Ash.create!()
+
+    tag_id = tag.id
+
+    resp =
+      """
+      query GetTagByOtherId($otherId: ID!) {
+        getTagByOtherId(otherId: $otherId) {
+          id
+          name
+        }
+      }
+      """
+      |> Absinthe.run(AshGraphql.Test.Schema, variables: %{"otherId" => tag_id})
+
+    assert {:ok, result} = resp
+
+    refute Map.has_key?(result, :errors)
+
+    assert %{data: %{"getTagByOtherId" => %{"id" => ^tag_id, "name" => "foo"}}} = result
+  end
+
   test "domain tracer configuration is correctly retrieved" do
     # Create a test domain with tracer configuration
     defmodule TestDomainWithTracer do

--- a/test/support/resources/tag.ex
+++ b/test/support/resources/tag.ex
@@ -18,6 +18,7 @@ defmodule AshGraphql.Test.Tag do
 
     queries do
       get :get_tag, :read, labels: [:public, :backoffice]
+      get :get_tag_by_other_id, :read, identity: :other_id
       list :get_tags, :read, labels: [:admin]
     end
 
@@ -45,11 +46,18 @@ defmodule AshGraphql.Test.Tag do
 
   calculations do
     calculate(:double_popularity, :integer, expr(popularity * 2), public?: true)
+    calculate(:other_id, :uuid, expr(id), public?: true)
   end
 
   identities do
     identity(:name, [:name], pre_check_with: AshGraphql.Test.Domain)
+    identity(:other_id, [:other_id])
   end
+
+  # `:other_id` is a calculation, and Ash refuses to pre/eager check identities
+  # built on calculated fields. Defining `testing_identities/0` opts this
+  # resource out of the ETS data layer's `pre_check_with` requirement.
+  def testing_identities, do: true
 
   relationships do
     many_to_many(:posts, AshGraphql.Test.Post,


### PR DESCRIPTION
A `get` query with `identity:` (and `update`/`destroy` mutations with an identity) looked up each identity key with
`Ash.Resource.Info.attribute/2`, which returns `nil` for a calculation. Building the argument then raised `KeyError: key :type not found in: nil` at schema compile time, so identities backed by a filterable calculation could not be used at all.

Use `Ash.Resource.Info.field/2` instead, which resolves attributes, calculations and aggregates alike and exposes the same `type` and `description`. The primary-key path is left alone, as it is always attributes.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
