### PR TITLE
Add deprecation support for GraphQL queries, mutations, and subscriptions

### DIFF
--- a/documentation/dsls/DSL-AshGraphql.Domain.md
+++ b/documentation/dsls/DSL-AshGraphql.Domain.md
@@ -103,6 +103,7 @@ get :get_post, :read
 | [`allow_nil?`](#graphql-queries-get-allow_nil?){: #graphql-queries-get-allow_nil? } | `boolean` | `true` | Whether or not the action can return nil. |
 | [`type_name`](#graphql-queries-get-type_name){: #graphql-queries-get-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-get-description){: #graphql-queries-get-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-get-deprecate){: #graphql-queries-get-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-get-metadata_names){: #graphql-queries-get-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-get-metadata_types){: #graphql-queries-get-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-get-show_metadata){: #graphql-queries-get-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -154,6 +155,7 @@ read_one :current_user, :current_user
 | [`allow_nil?`](#graphql-queries-read_one-allow_nil?){: #graphql-queries-read_one-allow_nil? } | `boolean` | `true` | Whether or not the action can return nil. |
 | [`type_name`](#graphql-queries-read_one-type_name){: #graphql-queries-read_one-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-read_one-description){: #graphql-queries-read_one-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-read_one-deprecate){: #graphql-queries-read_one-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-read_one-metadata_names){: #graphql-queries-read_one-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-read_one-metadata_types){: #graphql-queries-read_one-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-read_one-show_metadata){: #graphql-queries-read_one-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -210,6 +212,7 @@ list :list_posts_paginated, :read, relay?: true
 | [`paginate_with`](#graphql-queries-list-paginate_with){: #graphql-queries-list-paginate_with } | `:keyset \| :offset \| nil` | `:keyset` | Determine the pagination strategy to use, if multiple are available. If `nil`, no pagination is applied, otherwise the given strategy is used. |
 | [`type_name`](#graphql-queries-list-type_name){: #graphql-queries-list-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-list-description){: #graphql-queries-list-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-list-deprecate){: #graphql-queries-list-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-list-metadata_names){: #graphql-queries-list-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-list-metadata_types){: #graphql-queries-list-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-list-show_metadata){: #graphql-queries-list-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -259,6 +262,7 @@ action :check_status, :check_status
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`description`](#graphql-queries-action-description){: #graphql-queries-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-action-deprecate){: #graphql-queries-action-deprecate } | `boolean \| String.t` |  | Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-queries-action-hide_inputs){: #graphql-queries-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-queries-action-error_location){: #graphql-queries-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
 | [`modify_resolution`](#graphql-queries-action-modify_resolution){: #graphql-queries-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
@@ -330,6 +334,7 @@ create :create_post, :create
 | [`upsert?`](#graphql-mutations-create-upsert?){: #graphql-mutations-create-upsert? } | `boolean` | `false` | Whether or not to use the `upsert?: true` option when calling `YourDomain.create/2`. |
 | [`upsert_identity`](#graphql-mutations-create-upsert_identity){: #graphql-mutations-create-upsert_identity } | `atom` | `false` | Which identity to use for the upsert |
 | [`description`](#graphql-mutations-create-description){: #graphql-mutations-create-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-create-deprecate){: #graphql-mutations-create-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-create-relay_id_translations){: #graphql-mutations-create-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-create-args){: #graphql-mutations-create-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-create-hide_inputs){: #graphql-mutations-create-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -378,6 +383,7 @@ update :update_post, :update
 | [`identity`](#graphql-mutations-update-identity){: #graphql-mutations-update-identity } | `atom` |  | The identity to use to fetch the record to be updated. Use `false` if no identity is required. |
 | [`read_action`](#graphql-mutations-update-read_action){: #graphql-mutations-update-read_action } | `atom` |  | The read action to use to fetch the record to be updated. Defaults to the primary read action. |
 | [`description`](#graphql-mutations-update-description){: #graphql-mutations-update-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-update-deprecate){: #graphql-mutations-update-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-update-relay_id_translations){: #graphql-mutations-update-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-update-args){: #graphql-mutations-update-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-update-hide_inputs){: #graphql-mutations-update-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -426,6 +432,7 @@ destroy :destroy_post, :destroy
 | [`identity`](#graphql-mutations-destroy-identity){: #graphql-mutations-destroy-identity } | `atom` |  | The identity to use to fetch the record to be destroyed. Use `false` if no identity is required. |
 | [`read_action`](#graphql-mutations-destroy-read_action){: #graphql-mutations-destroy-read_action } | `atom` |  | The read action to use to fetch the record to be destroyed. Defaults to the primary read action. |
 | [`description`](#graphql-mutations-destroy-description){: #graphql-mutations-destroy-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-destroy-deprecate){: #graphql-mutations-destroy-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-destroy-relay_id_translations){: #graphql-mutations-destroy-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-destroy-args){: #graphql-mutations-destroy-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-destroy-hide_inputs){: #graphql-mutations-destroy-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -472,6 +479,7 @@ action :check_status, :check_status
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`description`](#graphql-mutations-action-description){: #graphql-mutations-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-action-deprecate){: #graphql-mutations-action-deprecate } | `boolean \| String.t` |  | Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-mutations-action-hide_inputs){: #graphql-mutations-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-mutations-action-error_location){: #graphql-mutations-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
 | [`modify_resolution`](#graphql-mutations-action-modify_resolution){: #graphql-mutations-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
@@ -555,6 +563,7 @@ end
 | [`actions`](#graphql-subscriptions-subscribe-actions){: #graphql-subscriptions-subscribe-actions } | `list(atom) \| atom` |  | The create/update/destroy actions the subsciption should listen to. |
 | [`action_types`](#graphql-subscriptions-subscribe-action_types){: #graphql-subscriptions-subscribe-action_types } | `list(atom) \| atom` |  | The type of actions the subsciption should listen to. |
 | [`read_action`](#graphql-subscriptions-subscribe-read_action){: #graphql-subscriptions-subscribe-read_action } | `atom` |  | The read action to use for reading data |
+| [`deprecate`](#graphql-subscriptions-subscribe-deprecate){: #graphql-subscriptions-subscribe-deprecate } | `boolean \| String.t` |  | Marks the subscription as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-subscriptions-subscribe-hide_inputs){: #graphql-subscriptions-subscribe-hide_inputs } | `list(atom)` | `[]` | A list of inputs to hide from the subscription, usable if the read action has arguments. |
 | [`relay_id_translations`](#graphql-subscriptions-subscribe-relay_id_translations){: #graphql-subscriptions-subscribe-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`meta`](#graphql-subscriptions-subscribe-meta){: #graphql-subscriptions-subscribe-meta } | `keyword` |  | A keyword list of metadata to include in the subscription. |

--- a/documentation/dsls/DSL-AshGraphql.Resource.md
+++ b/documentation/dsls/DSL-AshGraphql.Resource.md
@@ -149,6 +149,7 @@ get :get_post, :read
 | [`allow_nil?`](#graphql-queries-get-allow_nil?){: #graphql-queries-get-allow_nil? } | `boolean` | `true` | Whether or not the action can return nil. |
 | [`type_name`](#graphql-queries-get-type_name){: #graphql-queries-get-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-get-description){: #graphql-queries-get-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-get-deprecate){: #graphql-queries-get-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-get-metadata_names){: #graphql-queries-get-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-get-metadata_types){: #graphql-queries-get-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-get-show_metadata){: #graphql-queries-get-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -199,6 +200,7 @@ read_one :current_user, :current_user
 | [`allow_nil?`](#graphql-queries-read_one-allow_nil?){: #graphql-queries-read_one-allow_nil? } | `boolean` | `true` | Whether or not the action can return nil. |
 | [`type_name`](#graphql-queries-read_one-type_name){: #graphql-queries-read_one-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-read_one-description){: #graphql-queries-read_one-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-read_one-deprecate){: #graphql-queries-read_one-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-read_one-metadata_names){: #graphql-queries-read_one-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-read_one-metadata_types){: #graphql-queries-read_one-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-read_one-show_metadata){: #graphql-queries-read_one-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -254,6 +256,7 @@ list :list_posts_paginated, :read, relay?: true
 | [`paginate_with`](#graphql-queries-list-paginate_with){: #graphql-queries-list-paginate_with } | `:keyset \| :offset \| nil` | `:keyset` | Determine the pagination strategy to use, if multiple are available. If `nil`, no pagination is applied, otherwise the given strategy is used. |
 | [`type_name`](#graphql-queries-list-type_name){: #graphql-queries-list-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-list-description){: #graphql-queries-list-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-list-deprecate){: #graphql-queries-list-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-list-metadata_names){: #graphql-queries-list-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-list-metadata_types){: #graphql-queries-list-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-list-show_metadata){: #graphql-queries-list-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -302,6 +305,7 @@ action :check_status, :check_status
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`description`](#graphql-queries-action-description){: #graphql-queries-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-action-deprecate){: #graphql-queries-action-deprecate } | `boolean \| String.t` |  | Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-queries-action-hide_inputs){: #graphql-queries-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-queries-action-error_location){: #graphql-queries-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
 | [`modify_resolution`](#graphql-queries-action-modify_resolution){: #graphql-queries-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
@@ -374,6 +378,7 @@ get :get_post, :read
 | [`allow_nil?`](#graphql-queries-group-get-allow_nil?){: #graphql-queries-group-get-allow_nil? } | `boolean` | `true` | Whether or not the action can return nil. |
 | [`type_name`](#graphql-queries-group-get-type_name){: #graphql-queries-group-get-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-group-get-description){: #graphql-queries-group-get-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-group-get-deprecate){: #graphql-queries-group-get-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-group-get-metadata_names){: #graphql-queries-group-get-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-group-get-metadata_types){: #graphql-queries-group-get-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-group-get-show_metadata){: #graphql-queries-group-get-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -424,6 +429,7 @@ read_one :current_user, :current_user
 | [`allow_nil?`](#graphql-queries-group-read_one-allow_nil?){: #graphql-queries-group-read_one-allow_nil? } | `boolean` | `true` | Whether or not the action can return nil. |
 | [`type_name`](#graphql-queries-group-read_one-type_name){: #graphql-queries-group-read_one-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-group-read_one-description){: #graphql-queries-group-read_one-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-group-read_one-deprecate){: #graphql-queries-group-read_one-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-group-read_one-metadata_names){: #graphql-queries-group-read_one-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-group-read_one-metadata_types){: #graphql-queries-group-read_one-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-group-read_one-show_metadata){: #graphql-queries-group-read_one-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -479,6 +485,7 @@ list :list_posts_paginated, :read, relay?: true
 | [`paginate_with`](#graphql-queries-group-list-paginate_with){: #graphql-queries-group-list-paginate_with } | `:keyset \| :offset \| nil` | `:keyset` | Determine the pagination strategy to use, if multiple are available. If `nil`, no pagination is applied, otherwise the given strategy is used. |
 | [`type_name`](#graphql-queries-group-list-type_name){: #graphql-queries-group-list-type_name } | `atom` |  | Override the type name returned by this query. Must be set if the read action has `metadata` that is not hidden via the `show_metadata` key. |
 | [`description`](#graphql-queries-group-list-description){: #graphql-queries-group-list-description } | `String.t` |  | The query description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-group-list-deprecate){: #graphql-queries-group-list-deprecate } | `boolean \| String.t` |  | Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`metadata_names`](#graphql-queries-group-list-metadata_names){: #graphql-queries-group-list-metadata_names } | `keyword` | `[]` | Name overrides for metadata fields on the read action. |
 | [`metadata_types`](#graphql-queries-group-list-metadata_types){: #graphql-queries-group-list-metadata_types } | `keyword` | `[]` | Type overrides for metadata fields on the read action. |
 | [`show_metadata`](#graphql-queries-group-list-show_metadata){: #graphql-queries-group-list-show_metadata } | `list(atom)` |  | The metadata attributes to show. Defaults to all. |
@@ -527,6 +534,7 @@ action :check_status, :check_status
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`description`](#graphql-queries-group-action-description){: #graphql-queries-group-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-queries-group-action-deprecate){: #graphql-queries-group-action-deprecate } | `boolean \| String.t` |  | Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-queries-group-action-hide_inputs){: #graphql-queries-group-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-queries-group-action-error_location){: #graphql-queries-group-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
 | [`modify_resolution`](#graphql-queries-group-action-modify_resolution){: #graphql-queries-group-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
@@ -606,6 +614,7 @@ create :create_post, :create
 | [`upsert?`](#graphql-mutations-create-upsert?){: #graphql-mutations-create-upsert? } | `boolean` | `false` | Whether or not to use the `upsert?: true` option when calling `YourDomain.create/2`. |
 | [`upsert_identity`](#graphql-mutations-create-upsert_identity){: #graphql-mutations-create-upsert_identity } | `atom` | `false` | Which identity to use for the upsert |
 | [`description`](#graphql-mutations-create-description){: #graphql-mutations-create-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-create-deprecate){: #graphql-mutations-create-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-create-relay_id_translations){: #graphql-mutations-create-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-create-args){: #graphql-mutations-create-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-create-hide_inputs){: #graphql-mutations-create-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -653,6 +662,7 @@ update :update_post, :update
 | [`identity`](#graphql-mutations-update-identity){: #graphql-mutations-update-identity } | `atom` |  | The identity to use to fetch the record to be updated. Use `false` if no identity is required. |
 | [`read_action`](#graphql-mutations-update-read_action){: #graphql-mutations-update-read_action } | `atom` |  | The read action to use to fetch the record to be updated. Defaults to the primary read action. |
 | [`description`](#graphql-mutations-update-description){: #graphql-mutations-update-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-update-deprecate){: #graphql-mutations-update-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-update-relay_id_translations){: #graphql-mutations-update-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-update-args){: #graphql-mutations-update-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-update-hide_inputs){: #graphql-mutations-update-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -700,6 +710,7 @@ destroy :destroy_post, :destroy
 | [`identity`](#graphql-mutations-destroy-identity){: #graphql-mutations-destroy-identity } | `atom` |  | The identity to use to fetch the record to be destroyed. Use `false` if no identity is required. |
 | [`read_action`](#graphql-mutations-destroy-read_action){: #graphql-mutations-destroy-read_action } | `atom` |  | The read action to use to fetch the record to be destroyed. Defaults to the primary read action. |
 | [`description`](#graphql-mutations-destroy-description){: #graphql-mutations-destroy-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-destroy-deprecate){: #graphql-mutations-destroy-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-destroy-relay_id_translations){: #graphql-mutations-destroy-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-destroy-args){: #graphql-mutations-destroy-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-destroy-hide_inputs){: #graphql-mutations-destroy-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -745,6 +756,7 @@ action :check_status, :check_status
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`description`](#graphql-mutations-action-description){: #graphql-mutations-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-action-deprecate){: #graphql-mutations-action-deprecate } | `boolean \| String.t` |  | Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-mutations-action-hide_inputs){: #graphql-mutations-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-mutations-action-error_location){: #graphql-mutations-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
 | [`modify_resolution`](#graphql-mutations-action-modify_resolution){: #graphql-mutations-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
@@ -818,6 +830,7 @@ create :create_post, :create
 | [`upsert?`](#graphql-mutations-group-create-upsert?){: #graphql-mutations-group-create-upsert? } | `boolean` | `false` | Whether or not to use the `upsert?: true` option when calling `YourDomain.create/2`. |
 | [`upsert_identity`](#graphql-mutations-group-create-upsert_identity){: #graphql-mutations-group-create-upsert_identity } | `atom` | `false` | Which identity to use for the upsert |
 | [`description`](#graphql-mutations-group-create-description){: #graphql-mutations-group-create-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-group-create-deprecate){: #graphql-mutations-group-create-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-group-create-relay_id_translations){: #graphql-mutations-group-create-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-group-create-args){: #graphql-mutations-group-create-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-group-create-hide_inputs){: #graphql-mutations-group-create-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -865,6 +878,7 @@ update :update_post, :update
 | [`identity`](#graphql-mutations-group-update-identity){: #graphql-mutations-group-update-identity } | `atom` |  | The identity to use to fetch the record to be updated. Use `false` if no identity is required. |
 | [`read_action`](#graphql-mutations-group-update-read_action){: #graphql-mutations-group-update-read_action } | `atom` |  | The read action to use to fetch the record to be updated. Defaults to the primary read action. |
 | [`description`](#graphql-mutations-group-update-description){: #graphql-mutations-group-update-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-group-update-deprecate){: #graphql-mutations-group-update-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-group-update-relay_id_translations){: #graphql-mutations-group-update-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-group-update-args){: #graphql-mutations-group-update-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-group-update-hide_inputs){: #graphql-mutations-group-update-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -912,6 +926,7 @@ destroy :destroy_post, :destroy
 | [`identity`](#graphql-mutations-group-destroy-identity){: #graphql-mutations-group-destroy-identity } | `atom` |  | The identity to use to fetch the record to be destroyed. Use `false` if no identity is required. |
 | [`read_action`](#graphql-mutations-group-destroy-read_action){: #graphql-mutations-group-destroy-read_action } | `atom` |  | The read action to use to fetch the record to be destroyed. Defaults to the primary read action. |
 | [`description`](#graphql-mutations-group-destroy-description){: #graphql-mutations-group-destroy-description } | `String.t` |  | The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-group-destroy-deprecate){: #graphql-mutations-group-destroy-deprecate } | `boolean \| String.t` |  | Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`relay_id_translations`](#graphql-mutations-group-destroy-relay_id_translations){: #graphql-mutations-group-destroy-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`args`](#graphql-mutations-group-destroy-args){: #graphql-mutations-group-destroy-args } | `list(atom)` |  | A list of action attributes or arguments that should get their own arguments in the mutation instead of being passed in an input object. |
 | [`hide_inputs`](#graphql-mutations-group-destroy-hide_inputs){: #graphql-mutations-group-destroy-hide_inputs } | `list(atom)` |  | A list of inputs to hide from the mutation. |
@@ -957,6 +972,7 @@ action :check_status, :check_status
 | Name | Type | Default | Docs |
 |------|------|---------|------|
 | [`description`](#graphql-mutations-group-action-description){: #graphql-mutations-group-action-description } | `String.t` |  | The description that gets shown in the Graphql schema. If not provided, the action description will be used. |
+| [`deprecate`](#graphql-mutations-group-action-deprecate){: #graphql-mutations-group-action-deprecate } | `boolean \| String.t` |  | Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-mutations-group-action-hide_inputs){: #graphql-mutations-group-action-hide_inputs } | `list(atom)` | `[]` | Inputs to hide in the mutation/query |
 | [`error_location`](#graphql-mutations-group-action-error_location){: #graphql-mutations-group-action-error_location } | `:in_result \| :top_level` | `:top_level` | If the result should have an `errors` and a `result` key (like create/update/destroy mutations), or if errors should be shown in the top level errors key |
 | [`modify_resolution`](#graphql-mutations-group-action-modify_resolution){: #graphql-mutations-group-action-modify_resolution } | `mfa` |  | An MFA that will be called with the resolution, the query, and the result of the action as the first three arguments. See the [the guide](/documentation/topics/modifying-the-resolution.html) for more. |
@@ -1042,6 +1058,7 @@ end
 | [`actions`](#graphql-subscriptions-subscribe-actions){: #graphql-subscriptions-subscribe-actions } | `list(atom) \| atom` |  | The create/update/destroy actions the subsciption should listen to. |
 | [`action_types`](#graphql-subscriptions-subscribe-action_types){: #graphql-subscriptions-subscribe-action_types } | `list(atom) \| atom` |  | The type of actions the subsciption should listen to. |
 | [`read_action`](#graphql-subscriptions-subscribe-read_action){: #graphql-subscriptions-subscribe-read_action } | `atom` |  | The read action to use for reading data |
+| [`deprecate`](#graphql-subscriptions-subscribe-deprecate){: #graphql-subscriptions-subscribe-deprecate } | `boolean \| String.t` |  | Marks the subscription as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason. |
 | [`hide_inputs`](#graphql-subscriptions-subscribe-hide_inputs){: #graphql-subscriptions-subscribe-hide_inputs } | `list(atom)` | `[]` | A list of inputs to hide from the subscription, usable if the read action has arguments. |
 | [`relay_id_translations`](#graphql-subscriptions-subscribe-relay_id_translations){: #graphql-subscriptions-subscribe-relay_id_translations } | `keyword` | `[]` | A keyword list indicating arguments or attributes that have to be translated from global Relay IDs to internal IDs. See the [Relay guide](/documentation/topics/relay.md#translating-relay-global-ids-passed-as-arguments) for more. |
 | [`meta`](#graphql-subscriptions-subscribe-meta){: #graphql-subscriptions-subscribe-meta } | `keyword` |  | A keyword list of metadata to include in the subscription. |

--- a/lib/resource/mutation.ex
+++ b/lib/resource/mutation.ex
@@ -16,6 +16,7 @@ defmodule AshGraphql.Resource.Mutation do
     :modify_resolution,
     :relay_id_translations,
     :description,
+    :deprecate,
     :result_name,
     :__spark_metadata__,
     args: [],
@@ -40,6 +41,11 @@ defmodule AshGraphql.Resource.Mutation do
       type: :string,
       doc:
         "The mutation description that gets shown in the Graphql schema. If not provided, the action description will be used."
+    ],
+    deprecate: [
+      type: {:or, [:boolean, :string]},
+      doc:
+        "Marks the mutation as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason."
     ],
     relay_id_translations: [
       type: :keyword_list,

--- a/lib/resource/query.ex
+++ b/lib/resource/query.ex
@@ -14,6 +14,7 @@ defmodule AshGraphql.Resource.Query do
     :modify_resolution,
     :relay_id_translations,
     :description,
+    :deprecate,
     :complexity,
     :__spark_metadata__,
     as_mutation?: false,
@@ -50,6 +51,11 @@ defmodule AshGraphql.Resource.Query do
       type: :string,
       doc:
         "The query description that gets shown in the Graphql schema. If not provided, the action description will be used."
+    ],
+    deprecate: [
+      type: {:or, [:boolean, :string]},
+      doc:
+        "Marks the query as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason."
     ],
     metadata_names: [
       type: :keyword_list,

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -75,6 +75,11 @@ defmodule AshGraphql.Resource do
       doc:
         "The description that gets shown in the Graphql schema. If not provided, the action description will be used."
     ],
+    deprecate: [
+      type: {:or, [:boolean, :string]},
+      doc:
+        "Marks the action as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason."
+    ],
     hide_inputs: [
       type: {:list, :atom},
       doc: "Inputs to hide in the mutation/query",
@@ -119,6 +124,7 @@ defmodule AshGraphql.Resource do
       :action,
       :resource,
       :description,
+      :deprecate,
       :relay_id_translations,
       :error_location,
       :modify_resolution,
@@ -830,6 +836,7 @@ defmodule AshGraphql.Resource do
           module: schema,
           name: to_string(name),
           description: query.description || query_action.description,
+          directives: graphql_deprecation_directives(query.deprecate),
           type: generic_action_type(query_action, resource, domain, query, schema),
           __reference__: ref(__ENV__)
         }
@@ -872,6 +879,7 @@ defmodule AshGraphql.Resource do
           module: schema,
           name: to_string(query.name),
           description: query.description || query_action.description,
+          directives: graphql_deprecation_directives(query.deprecate),
           type: query_type(query, resource, query_action, type),
           __reference__: ref(__ENV__)
         }
@@ -909,6 +917,7 @@ defmodule AshGraphql.Resource do
         module: schema,
         name: to_string(mutation.name),
         description: mutation.description || action.description,
+        directives: graphql_deprecation_directives(mutation.deprecate),
         type: generic_action_type(action, resource, domain, mutation, schema),
         __reference__: ref(__ENV__)
       }
@@ -925,6 +934,7 @@ defmodule AshGraphql.Resource do
         module: schema,
         name: to_string(mutation.name),
         description: mutation.description || action.description,
+        directives: graphql_deprecation_directives(mutation.deprecate),
         type: mutation_result_type(mutation.name, domain),
         __reference__: ref(__ENV__)
       }
@@ -1790,6 +1800,22 @@ defmodule AshGraphql.Resource do
     []
   end
 
+  defp graphql_deprecation_directives(value) when value in [nil, false], do: []
+
+  defp graphql_deprecation_directives(true) do
+    [%Absinthe.Blueprint.Directive{name: "deprecated"}]
+  end
+
+  defp graphql_deprecation_directives(reason) when is_binary(reason) do
+    argument = %Absinthe.Blueprint.Input.Argument{
+      name: "reason",
+      input_value: Absinthe.Blueprint.Input.Value.build(reason),
+      source_location: nil
+    }
+
+    [%Absinthe.Blueprint.Directive{name: "deprecated", arguments: [argument]}]
+  end
+
   defp domain_middleware(domain) do
     [{{AshGraphql.Graphql.DomainMiddleware, :set_domain}, domain}]
   end
@@ -1849,6 +1875,7 @@ defmodule AshGraphql.Resource do
         arguments: args(:subscription, resource, action, schema, nil, hide_inputs),
         identifier: name,
         name: to_string(name),
+        directives: graphql_deprecation_directives(subscription.deprecate),
         config:
           AshGraphql.Subscription.Config.create_config(
             subscription,

--- a/lib/resource/subscription.ex
+++ b/lib/resource/subscription.ex
@@ -13,6 +13,7 @@ defmodule AshGraphql.Resource.Subscription do
     :actor,
     :hide_inputs,
     :relay_id_translations,
+    :deprecate,
     :meta,
     :__spark_metadata__
   ]
@@ -39,6 +40,11 @@ defmodule AshGraphql.Resource.Subscription do
     read_action: [
       type: :atom,
       doc: "The read action to use for reading data"
+    ],
+    deprecate: [
+      type: {:or, [:boolean, :string]},
+      doc:
+        "Marks the subscription as deprecated. Pass `true` to omit the reason, or a string to provide a deprecation reason."
     ],
     hide_inputs: [
       type: {:list, :atom},

--- a/test/deprecation_test.exs
+++ b/test/deprecation_test.exs
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2020 ash_graphql contributors <https://github.com/ash-project/ash_graphql/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshGraphql.DeprecationTest do
+  use ExUnit.Case
+
+  alias AshGraphql.Test.Schema
+
+  test "deprecations are exposed for every generated root operation" do
+    assert {:ok, %{data: data}} =
+             Absinthe.run(
+               """
+               query {
+                 __schema {
+                   queryType {
+                     fields(includeDeprecated: true) {
+                       name
+                       isDeprecated
+                       deprecationReason
+                     }
+                   }
+                   mutationType {
+                     fields(includeDeprecated: true) {
+                       name
+                       isDeprecated
+                       deprecationReason
+                     }
+                   }
+                   subscriptionType {
+                     fields(includeDeprecated: true) {
+                       name
+                       isDeprecated
+                       deprecationReason
+                     }
+                   }
+                 }
+                 groupType: __type(name: "ContentQueryGroup") {
+                   fields(includeDeprecated: true) {
+                     name
+                     isDeprecated
+                     deprecationReason
+                   }
+                 }
+               }
+               """,
+               Schema
+             )
+
+    query_fields = data["__schema"]["queryType"]["fields"]
+    mutation_fields = data["__schema"]["mutationType"]["fields"]
+    subscription_fields = data["__schema"]["subscriptionType"]["fields"]
+    grouped_query_fields = data["groupType"]["fields"]
+
+    assert_deprecation(query_fields, "deprecatedGetPost", nil)
+    assert_deprecation(query_fields, "deprecatedPostCount", "Use `postCount` instead.")
+
+    assert_deprecation(
+      query_fields,
+      "deprecatedDomainGetComment",
+      "Use `getComment` instead."
+    )
+
+    assert_deprecation(
+      mutation_fields,
+      "deprecatedCreatePost",
+      "Use `createPost` instead."
+    )
+
+    assert_deprecation(mutation_fields, "deprecatedRandomPost", nil)
+
+    assert_deprecation(
+      subscription_fields,
+      "subscribableEvents",
+      "Use `subscribedOnDomain` instead."
+    )
+
+    assert_deprecation(subscription_fields, "subscribedOnDomain", nil)
+    assert_deprecation(grouped_query_fields, "gqDeprecatedStats", nil)
+
+    assert %{
+             "isDeprecated" => false,
+             "deprecationReason" => nil
+           } = field(query_fields, "getPost")
+  end
+
+  test "deprecated operations are omitted from introspection by default" do
+    assert {:ok, %{data: %{"__type" => %{"fields" => fields}}}} =
+             Absinthe.run(
+               """
+               query {
+                 __type(name: "RootQueryType") {
+                   fields {
+                     name
+                   }
+                 }
+               }
+               """,
+               Schema
+             )
+
+    names = Enum.map(fields, & &1["name"])
+
+    assert "getPost" in names
+    refute "deprecatedGetPost" in names
+    refute "deprecatedPostCount" in names
+    refute "deprecatedDomainGetComment" in names
+  end
+
+  test "SDL includes deprecated directives with and without reasons" do
+    sdl = Absinthe.Schema.to_sdl(Schema)
+
+    assert sdl =~ ~r/deprecatedGetPost\([^)]*\): Post @deprecated\n/s
+
+    assert sdl =~
+             ~s|deprecatedPostCount(published: Boolean): Int! @deprecated(reason: "Use `postCount` instead.")|
+  end
+
+  defp assert_deprecation(fields, name, reason) do
+    assert %{
+             "isDeprecated" => true,
+             "deprecationReason" => ^reason
+           } = field(fields, name)
+  end
+
+  defp field(fields, name) do
+    Enum.find(fields, &(&1["name"] == name))
+  end
+end

--- a/test/flatten_query_mutation_groups_test.exs
+++ b/test/flatten_query_mutation_groups_test.exs
@@ -12,12 +12,13 @@ defmodule AshGraphql.FlattenQueryMutationGroupsTest do
     entities =
       Extension.get_entities(AshGraphql.Test.GroupedQueriesResource, [:graphql, :queries])
 
-    assert length(entities) == 2
+    assert length(entities) == 3
 
     assert Enum.all?(entities, &(&1.group == :content))
 
     assert Enum.any?(entities, &match?(%Resource.Query{}, &1))
     assert Enum.any?(entities, &match?(%Resource.Action{}, &1))
+    assert Enum.any?(entities, &(&1.name == :gq_deprecated_stats && &1.deprecate == true))
   end
 
   test "duplicate graphql query names inside one group fail compilation" do

--- a/test/support/domain.ex
+++ b/test/support/domain.ex
@@ -14,6 +14,10 @@ defmodule AshGraphql.Test.Domain do
   graphql do
     queries do
       get AshGraphql.Test.Comment, :get_comment, :read
+
+      get AshGraphql.Test.Comment, :deprecated_domain_get_comment, :read,
+        deprecate: "Use `getComment` instead."
+
       list AshGraphql.Test.Post, :post_score, :score
     end
 
@@ -22,6 +26,7 @@ defmodule AshGraphql.Test.Domain do
 
       subscribe AshGraphql.Test.Subscribable, :subscribed_on_domain do
         action_types(:create)
+        deprecate(true)
       end
 
       subscribe AshGraphql.Test.DomainLevelPubsubResource, :domain_pubsub_subscription do

--- a/test/support/resources/grouped_queries_resource.ex
+++ b/test/support/resources/grouped_queries_resource.ex
@@ -18,6 +18,7 @@ defmodule AshGraphql.Test.GroupedQueriesResource do
         list(:gq_unique_items, :read, labels: [:public])
 
         action(:gq_unique_stats, :stats, labels: [:admin])
+        action(:gq_deprecated_stats, :stats, deprecate: true)
       end
     end
   end

--- a/test/support/resources/post.ex
+++ b/test/support/resources/post.ex
@@ -200,7 +200,8 @@ defmodule AshGraphql.Test.Post do
     paginate_relationship_with unpaginated_comments: :none
 
     queries do
-      get :get_post, :read
+      get :get_post, :read, deprecate: false
+      get :deprecated_get_post, :read, deprecate: true
       get :get_post_with_custom_description, :read, description: "A custom description"
       list :post_library, :library
       list :paginated_posts, :paginated
@@ -212,6 +213,8 @@ defmodule AshGraphql.Test.Post do
       list :read_post_with_invalid_arguments_names, :read_with_invalid_arguments_names
       list :lazyinit_search, :search
       action(:post_count, :count, labels: [:admin])
+      action(:deprecated_post_count, :count, deprecate: "Use `postCount` instead.")
+
       action(:post_count_with_errors, :count, error_location: :in_result)
 
       action(
@@ -256,6 +259,8 @@ defmodule AshGraphql.Test.Post do
       create :create_post_with_custom_description, :create,
         description: "Another custom description"
 
+      create :deprecated_create_post, :create, deprecate: "Use `createPost` instead."
+
       create :create_post_with_invalid_arguments_names, :create_with_invalid_arguments_names
 
       update :update_post, :update, labels: [:admin]
@@ -283,6 +288,7 @@ defmodule AshGraphql.Test.Post do
 
       # this is a mutation just for testing
       action(:random_post, :random)
+      action(:deprecated_random_post, :random, deprecate: true)
       action(:random_post_with_arg, :random, args: [:published])
     end
   end

--- a/test/support/resources/subscribable.ex
+++ b/test/support/resources/subscribable.ex
@@ -31,6 +31,7 @@ defmodule AshGraphql.Test.Subscribable do
 
       subscribe(:subscribable_events) do
         action_types([:create, :update, :destroy])
+        deprecate("Use `subscribedOnDomain` instead.")
       end
 
       subscribe(:deduped_subscribable_events) do


### PR DESCRIPTION
## Summary

Adds support for deprecating GraphQL queries, mutations, and subscriptions through the AshGraphql DSL.

Operations can now set `deprecate` to:

- `true` to mark the operation as deprecated without an explicit reason.
- A string to include a deprecation reason.

The generated GraphQL schema applies the corresponding `@deprecated` directive to resource- and domain-level operations, including generic actions and grouped queries. Existing operations remain unchanged when the option is omitted.

## Testing

- Added introspection coverage for deprecated queries, mutations, subscriptions, and grouped queries.
- Verified custom deprecation reasons and reasonless deprecations.
- Verified deprecated operations are excluded from introspection unless `includeDeprecated: true` is provided.
- Verified the generated SDL includes the expected `@deprecated` directives.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies